### PR TITLE
Roll separation proposal to allow for future use of common roll and chat functions

### DIFF
--- a/module/apps/dice-roll-app.mjs
+++ b/module/apps/dice-roll-app.mjs
@@ -122,7 +122,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
             this.rollWithDisadvantage = true;
             this.rollWithAdvantage = false;
         }
-        else if(modifierAdvantage === 3){handleClickedRollAdvantage
+        else if(modifierAdvantage === 3){//handleClickedRollAdvantage
             this.rollWithDisadvantage = true;
             this.rollWithAdvantage = true;
         }
@@ -288,3 +288,169 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
         this.close();
     }
 }
+
+
+// // ========================================================================
+// // Potential implementation of SkillRollWorkflow refactor for DiceRollApp 
+// // As strictly UI gathering functions passing logic to SkillRollWorkflow with helper functions can then be extended for other roll types/dialogs/chat activation buttons etc..
+// // Injury/Trauma, Rerolls, d3 rolls.
+// // ========================================================================
+
+// import { SkillRollWorkflow } from "../rolls/skill-roll-workflow.mjs";
+
+// const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+
+// export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
+//   constructor(options = {}) {
+//     super(options);
+
+//     this.actor = options.actor;
+//     this.skillKey = options.skillKey;
+//     this.skillCurrent = options.skillCurrent;
+//     this.skillMax = options.skillMax;
+//     this.currentDicePool = options.currentDicePool;
+
+//     // Single canonical "book" of parameters
+//     // (UI template context reads from here; workflow reads from here)
+//     // NOTE: ApplicationV2 already has a getter-only `state`, so we must not assign to `this.state`.
+//     this.rollState = {
+//       skillKey: this.skillKey,
+//       skillCurrent: this.skillCurrent,
+//       skillMax: this.skillMax,
+//       currentDicePool: this.currentDicePool,
+
+//       diceToUse: 0,
+//       penalty: 0,
+//       bonusDice: 0,
+//       successesNeeded: 0,
+
+//       rollWithAdvantage: false,
+//       rollWithDisadvantage: false,
+//     };
+
+//     DiceRollApp.instance = this;
+//   }
+
+//   /** @inheritDoc */
+//   static DEFAULT_OPTIONS = {
+//     id: "dice-roll-app",
+//     classes: ["dialog", "dice-roll-app"],
+//     tag: "div",
+//     window: {
+//       frame: true,
+//       title: "Dice Roll",
+//       icon: "fa-solid fa-book-atlas",
+//       positioned: true,
+//       resizable: true,
+//     },
+//     position: {
+//       width: 400,
+//       height: 450,
+//     },
+//     actions: {
+//       clickedRoll: this.#handleClickedRoll,
+//     },
+//   };
+
+//   /** @override */
+//   static PARTS = {
+//     dialog: {
+//       template: "systems/arkham-horror-rpg-fvtt/templates/dice-roll-app/dialog.hbs",
+//       scrollable: [""],
+//     },
+//   };
+
+//   setOptions(options = {}) {
+//     if (options.actor) this.actor = options.actor;
+//     if (options.skillKey) this.skillKey = options.skillKey;
+//     if (options.skillCurrent !== undefined) this.skillCurrent = options.skillCurrent;
+//     if (options.skillMax !== undefined) this.skillMax = options.skillMax;
+//     if (options.currentDicePool !== undefined) this.currentDicePool = options.currentDicePool;
+
+//     // Keep rollState in sync (single book)
+//     this.rollState.skillKey = this.skillKey;
+//     this.rollState.skillCurrent = this.skillCurrent;
+//     this.rollState.skillMax = this.skillMax;
+//     this.rollState.currentDicePool = this.currentDicePool;
+
+//     // Reset transient roll modifiers like your original code
+//     this.rollState.rollWithAdvantage = false;
+//     this.rollState.rollWithDisadvantage = false;
+//     this.rollState.bonusDice = 0;
+//     this.rollState.penalty = 0;
+//     this.rollState.successesNeeded = 0;
+//   }
+
+//   static getInstance(options = {}) {
+//     if (!DiceRollApp.instance) {
+//       DiceRollApp.instance = new DiceRollApp(options);
+//     }
+//     const instance = DiceRollApp.instance;
+//     instance.setOptions(options);
+//     return instance;
+//   }
+
+//   async _prepareContext(options) {
+//     const context = await super._prepareContext(options);
+
+//     // Feed template from rollState (no separate context mapping logic)
+//     return {
+//       ...context,
+
+//       actor: this.actor,
+
+//       // everything your template expects:
+//       skillKey: this.rollState.skillKey,
+//       skillCurrent: this.rollState.skillCurrent,
+//       skillMax: this.rollState.skillMax,
+//       currentDicePool: this.rollState.currentDicePool,
+//       diceToUse: this.rollState.diceToUse,
+
+//       // include these if your template shows them (optional)
+//       penalty: this.rollState.penalty,
+//       bonusDice: this.rollState.bonusDice,
+//       successesNeeded: this.rollState.successesNeeded,
+//       rollWithAdvantage: this.rollState.rollWithAdvantage,
+//       rollWithDisadvantage: this.rollState.rollWithDisadvantage,
+//     };
+//   }
+
+//   static async #handleClickedRoll(event, target) {
+//     this.clickedRollCallback(event, target);
+//   }
+
+//   async clickedRollCallback(event, target) {
+//     event.preventDefault();
+//     const form = target.form;
+
+//     // Update rollState FROM UI once
+//     this.rollState.skillCurrent = Number.parseInt(form.skillCurrent.value);
+//     this.rollState.diceToUse = Number.parseInt(form.diceToUse.value);
+//     this.rollState.penalty = Number.parseInt(form.penalty.value) || 0;
+//     this.rollState.bonusDice = Number.parseInt(form.bonus_dice.value) || 0;
+//     this.rollState.successesNeeded = Number.parseInt(form.difficulty.value) || 0;
+
+//     // Advantage / disadvantage selector logic (same as original intent)
+//     const modifierAdvantage = Number.parseInt(form.advantageModifier.value) || 0;
+//     if (modifierAdvantage === 1) {
+//       this.rollState.rollWithAdvantage = true;
+//       this.rollState.rollWithDisadvantage = false;
+//     } else if (modifierAdvantage === 2) {
+//       this.rollState.rollWithDisadvantage = true;
+//       this.rollState.rollWithAdvantage = false;
+//     } else if (modifierAdvantage === 3) {
+//       this.rollState.rollWithAdvantage = true;
+//       this.rollState.rollWithDisadvantage = true;
+//     } else {
+//       this.rollState.rollWithAdvantage = false;
+//       this.rollState.rollWithDisadvantage = false;
+//     }
+
+//     // Run workflow end-to-end (roll + update actor + post chat)
+//     // Keep parameter name "state" but pass the renamed property
+//     const workflow = new SkillRollWorkflow();
+//     await workflow.run({ actor: this.actor, state: this.rollState });
+
+//     this.close();
+//   }
+// }

--- a/module/helpers/chat-utils.mjs
+++ b/module/helpers/chat-utils.mjs
@@ -1,0 +1,12 @@
+// simplifys calling the Handlebars template renderer for chat messages allows easy updates if this moves around in the API in the future.
+export async function renderChatHtml(templatePath, chatVars) {
+  return foundry.applications.handlebars.renderTemplate(templatePath, chatVars);
+}
+
+// One place to handle top level chat message creation
+export async function postChatMessage({ actor, html }) {
+  return ChatMessage.create({
+    content: html,
+    speaker: ChatMessage.getSpeaker({ actor: actor }),
+  });
+}

--- a/module/helpers/roll-engine.mjs
+++ b/module/helpers/roll-engine.mjs
@@ -1,0 +1,152 @@
+// Functional implementation of helper functions for use by class based roll workflows see SkillWorkflow.mjs, etc.
+// Allows for composable roll pipelines to be developed.
+
+// Dice So Nice support integration
+export function addShowDicePromise(promises, roll) {
+  if (game.dice3d) {
+    // synchronize=true so DSN dice appear on all players' screens
+    promises.push(game.dice3d.showForRoll(roll, game.user, true, null, false));
+  }
+}
+
+// core d6 roll function
+export async function rollD6({ actor, numDice }) {
+  const roll = new Roll(`${numDice}d6`, actor.getRollData());
+  await roll.evaluate();
+
+  const promises = [];
+  addShowDicePromise(promises, roll);
+  await Promise.all(promises);
+
+  return {
+    roll,
+    html: await roll.render(),
+    results: roll.terms[0].results.map(r => r.result),
+  };
+}
+
+// Computes dice pools + success threshold exactly like original logic from 13.0.7 ALPHA dice-roll-app.
+export function calculatePoolsAndThresholds({
+  actor,
+  skillCurrent,
+  currentDicePool,
+  diceToUse,
+  penalty,
+  bonusDice,
+  rollWithAdvantage,
+  rollWithDisadvantage,
+}) {
+  let successOn = Number.parseInt(skillCurrent);
+  let diceToRoll = Number.parseInt(diceToUse);
+
+  const numHorrorDice = actor.system.horror;
+  let horrorDiceToRoll = 0;
+
+  if (numHorrorDice >= currentDicePool) {
+    // all dice are horror dice
+    horrorDiceToRoll = diceToUse;
+    diceToRoll = 0;
+  } else {
+    const normalDice = currentDicePool - numHorrorDice;
+    if (normalDice >= diceToUse) {
+      // all dice are normal dice
+      diceToRoll = diceToUse;
+    } else {
+      // some horror dice, some normal dice
+      horrorDiceToRoll = diceToUse - normalDice;
+      diceToRoll = normalDice;
+    }
+  }
+
+  const b = Number.parseInt(bonusDice) || 0;
+  diceToRoll += b;
+
+  const p = Number.parseInt(penalty) || 0;
+  if (p > 0) {
+    successOn += p;
+    if (successOn > 6) successOn = 6;
+  }
+
+  // advantage/disadvantage adds an extra die (then we drop one later)
+  if (rollWithAdvantage) diceToRoll += 1;
+  if (rollWithDisadvantage && diceToRoll > 0) diceToRoll += 1;
+
+  return {
+    successOn,
+    diceToUse: Number.parseInt(diceToUse),
+    diceToRoll,
+    horrorDiceToRoll,
+    penalty: p,
+    bonusDice: b,
+    rollWithAdvantage: !!rollWithAdvantage,
+    rollWithDisadvantage: !!rollWithDisadvantage,
+  };
+}
+
+//Combines normal + horror results into [{result,isHorror}]
+export function collectTaggedResults({ normalResults, horrorResults = [] }) {
+  const tagged = [];
+  normalResults.forEach(r => tagged.push({ result: r, isHorror: false }));
+  horrorResults.forEach(r => tagged.push({ result: r, isHorror: true }));
+  return tagged;
+}
+
+// Drops highest or lowest die based on advantage/disadvantage flags like original logic from 13.0.7 ALPHA dice-roll-app.
+// Note here that in the future we could use this same function rather than dropping we could tag the dice to show as dropped to the user on chat cards etc.
+export function applyAdvantageDisadvantageDrop(diceRollResults, { rollWithAdvantage, rollWithDisadvantage }) {
+  if (rollWithAdvantage) {
+    const minResult = Math.min(...diceRollResults.map(r => r.result));
+    const minIndex = diceRollResults.findIndex(r => r.result === minResult);
+    diceRollResults.splice(minIndex, 1);
+  }
+
+  if (rollWithDisadvantage) {
+    const maxResult = Math.max(...diceRollResults.map(r => r.result));
+    const maxIndex = diceRollResults.findIndex(r => r.result === maxResult);
+    diceRollResults.splice(maxIndex, 1);
+  }
+}
+
+// Computes final success/failure counts based on modified dice results like original logic from 13.0.7 ALPHA dice-roll-app.
+export function computeSkillOutcome(diceRollResults, { successOn, penalty, successesNeeded }) {
+  // count all results that are >= 6
+  let successCount = diceRollResults.filter(r => r.result >= 6).length;
+
+  // failures (1s)
+  const failureCount = diceRollResults.filter(r => r.result === 1 && !r.isHorror).length;
+  const horrorFailureCount = diceRollResults.filter(r => r.result === 1 && r.isHorror).length;
+
+  // keep 1s and 6s as-is
+  let finalDiceRollResults = diceRollResults.filter(r => r.result === 1 || r.result === 6);
+
+  // remaining dice (not 1 or 6)
+  let tmpDiceRollResults = diceRollResults.filter(r => r.result !== 1 && r.result !== 6);
+
+  // decrease remaining dice by penalty (consistent with original)
+  tmpDiceRollResults = tmpDiceRollResults.map(r => ({ ...r, result: r.result - penalty }));
+
+  // append remaining dice
+  finalDiceRollResults = finalDiceRollResults.concat(tmpDiceRollResults);
+
+  // check success threshold on modified dice now
+  successCount += tmpDiceRollResults.filter(r => r.result >= successOn).length;
+
+  const needed = Number.parseInt(successesNeeded) || 0;
+  const isSuccess = successCount >= needed;
+
+  return {
+    isSuccess,
+    successCount,
+    failureCount,
+    horrorFailureCount,
+    finalDiceRollResults,
+  };
+}
+
+// Deducts rolled dice from actor pool.
+export async function applyDicepoolCost(actor, diceToUse) {
+  const oldDicePoolValue = actor.system.dicepool.value;
+  const newDicePoolValue = Math.max(0, oldDicePoolValue - diceToUse);
+  await actor.update({ "system.dicepool.value": newDicePoolValue });
+  return { oldDicePoolValue, newDicePoolValue };
+}

--- a/module/rolls/skill-roll-workflow.mjs
+++ b/module/rolls/skill-roll-workflow.mjs
@@ -1,0 +1,126 @@
+import { 
+    rollD6, 
+    calculatePoolsAndThresholds,
+    collectTaggedResults,
+    applyAdvantageDisadvantageDrop,
+    computeSkillOutcome,
+    applyDicepoolCost,
+} from "../helpers/roll-engine.mjs";
+import { renderChatHtml, postChatMessage } from "../helpers/chat-utils.mjs";
+
+
+export class SkillRollWorkflow {
+  async plan({ actor, state }) {
+    // produce a plan identical to the old DiceRollService internal calculations
+    return calculatePoolsAndThresholds({
+      actor,
+      skillCurrent: state.skillCurrent,
+      currentDicePool: state.currentDicePool,
+      diceToUse: state.diceToUse,
+      penalty: state.penalty,
+      bonusDice: state.bonusDice,
+      rollWithAdvantage: state.rollWithAdvantage,
+      rollWithDisadvantage: state.rollWithDisadvantage,
+    });
+  }
+
+  async execute({ actor, state, plan }) {
+    // roll horror separately (so we can render separate HTML and tag)
+    const horror = plan.horrorDiceToRoll > 0
+      ? await rollD6({ actor, numDice: plan.horrorDiceToRoll })
+      : null;
+
+    const normal = await rollD6({ actor, numDice: plan.diceToRoll });
+
+    return { normal, horror };
+  }
+
+  computeOutcome({ actor, state, plan, exec }) {
+    const diceRollResults = collectTaggedResults({
+      normalResults: exec.normal.results,
+      horrorResults: exec.horror ? exec.horror.results : [],
+    });
+
+    
+    applyAdvantageDisadvantageDrop(diceRollResults, {
+      rollWithAdvantage: plan.rollWithAdvantage,
+      rollWithDisadvantage: plan.rollWithDisadvantage,
+    });
+
+    const outcome = computeSkillOutcome(diceRollResults, {
+      successOn: plan.successOn,
+      penalty: plan.penalty,
+      successesNeeded: state.successesNeeded,
+    });
+
+    return {
+      ...outcome,
+      successOn: plan.successOn,
+      diceToUse: plan.diceToUse,
+      horrorDiceToRoll: plan.horrorDiceToRoll,
+      penalty: plan.penalty,
+      bonusDice: plan.bonusDice,
+      successesNeeded: Number.parseInt(state.successesNeeded) || 0,
+      rollWithAdvantage: plan.rollWithAdvantage,
+      rollWithDisadvantage: plan.rollWithDisadvantage,
+      horrorDiceUsed: plan.horrorDiceToRoll > 0,
+      diceRollHTML: exec.normal.html,
+      horrorDiceRollHTML: exec.horror ? exec.horror.html : "",
+    };
+  }
+
+  async applyEffects({ actor, state, plan, exec, outcome }) {
+    // subtract used dice from actor's dicepool
+    const dicepoolDelta = await applyDicepoolCost(actor, outcome.diceToUse);
+    outcome.oldDicePoolValue = dicepoolDelta.oldDicePoolValue;
+    outcome.newDicePoolValue = dicepoolDelta.newDicePoolValue;
+  }
+
+  buildChat({ actor, state, plan, exec, outcome }) {
+    const template = "systems/arkham-horror-rpg-fvtt/templates/chat/roll-result.hbs";
+
+    const chatData = {
+      diceRollHTML: outcome.diceRollHTML,
+      horrorDiceRollHTML: outcome.horrorDiceRollHTML,
+      successOn: outcome.successOn,
+      diceToUse: outcome.diceToUse,
+      results: outcome.finalDiceRollResults,
+      successCount: outcome.successCount,
+      failureCount: outcome.failureCount,
+      skillUsed: game.i18n.localize(`ARKHAM_HORROR.SKILL.${state.skillKey}`),
+      newDicePoolValue: outcome.newDicePoolValue,
+      oldDicePoolValue: outcome.oldDicePoolValue,
+      horrorFailureCount: outcome.horrorFailureCount,
+      horrorDiceToRoll: outcome.horrorDiceToRoll,
+      isSuccess: outcome.isSuccess,
+      penalty: outcome.penalty,
+      bonusDice: outcome.bonusDice,
+      successesNeeded: outcome.successesNeeded,
+      rollWithAdvantage: outcome.rollWithAdvantage,
+      rollWithDisadvantage: outcome.rollWithDisadvantage,
+      horrorDiceUsed: outcome.horrorDiceUsed,
+    };
+
+    return { template, chatData };
+  }
+
+  async post({ actor, state, plan, exec, outcome }) {
+    const { template, chatData } = this.buildChat({ actor, state, plan, exec, outcome });
+    const html = await renderChatHtml(template, chatData);
+    const message = await postChatMessage({ actor, html });
+    return { html, message, chatData };
+  }
+
+  /**
+   * Convenience method: run end-to-end without an external orchestrator.
+   * (Optional; remove if you prefer a shared RollOrchestrator.)
+   */
+  async run({ actor, state }) {
+    const plan = await this.plan({ actor, state });
+    const exec = await this.execute({ actor, state, plan });
+    const outcome = this.computeOutcome({ actor, state, plan, exec });
+    await this.applyEffects({ actor, state, plan, exec, outcome });
+    const posted = await this.post({ actor, state, plan, exec, outcome });
+    return { plan, exec, outcome, ...posted };
+  }
+}


### PR DESCRIPTION
I am suggesting in this pull request a refactor of dice-roll-app's logic to create a separation of concerns between UI and roll logic, with a "headless" workflow class that controls sequencing of a set of common helper functions this allows for future implementation of different workflows that can call the same or other new functions as needed and be called from different dialogs.  This is just the refactor, but allows for easier feature development of the following:

Reroll action buttons from chat cards where a different dialog allowing the user to select the dice from the original roll to Reroll comes up and the same modifiers/penalties can be applied from the original roll, as long as they are passed in the original ChatMessage flags. 

Access to DSN function, as well as the standard d6 roll for roll types that are not Complex Actions (the only roll type handled by dice-roll-app)  without duplication of functions in the codebase for Injury Rolls / Trauma Rolls allowing look up the correct table information since this can't be done easily from a traditional roll table since it is a 1d6+mod system and not a proportional percentage as traditional foundry RollTables do.  Note: the below picture is from the 13.0.4 build and since dice-roll-app was updated in a recent commit I am trying to go more stepwise with this PR.

<img width="993" height="791" alt="image" src="https://github.com/user-attachments/assets/a05f0ed6-584b-43f5-bfe0-1f2e4ee5d8bc" />

I did not change the current function in DiceRollApp to implement the new workflow system however I did a small bug fix as an errant handleClickedRollAdvantage was stuck on line 125 causing adv/dis to not function properly.  I only commented this out to ensure that there was fidelity between the old and new proposed implementation which is commented at the bottom of the dice-roll-app.mjs file and you can test.  Looking forward to discussion and thoughts on this.  Thanks.


