### PR TITLE
Arkham Combat Tracker v1

### DIFF
--- a/module/arkham-horror-rpg-fvtt.mjs
+++ b/module/arkham-horror-rpg-fvtt.mjs
@@ -8,6 +8,7 @@ import { ArkhamHorrorItemSheet } from './sheets/item-sheet.mjs';
 // Import helper/utility classes and constants.
 import { preloadHandlebarsTemplates } from './helpers/templates.mjs';
 import { ARKHAM_HORROR } from './helpers/config.mjs';
+import { ArkhamHorrorCombatTracker } from './combat/combat-tracker.mjs';
 // Import DataModel classes
 import * as models from './data/_module.mjs';
 
@@ -26,6 +27,9 @@ Hooks.once('init', function () {
 
   // Add custom constants for configuration.
   CONFIG.ARKHAM_HORROR = ARKHAM_HORROR;
+
+  // Override the sidebar Combat Tracker UI (Arkham is side-based, not initiative-based).
+  CONFIG.ui.combat = ArkhamHorrorCombatTracker;
 
   /**
    * Set an initiative formula for the system

--- a/module/combat/combat-tracker.mjs
+++ b/module/combat/combat-tracker.mjs
@@ -1,0 +1,173 @@
+const FLAG_SCOPE = "arkham-horror-rpg-fvtt";
+const FLAG_FIRST = "firstSide";
+const FLAG_ACTIVE = "activeSide";
+
+export class ArkhamHorrorCombatTracker extends foundry.applications.sidebar.tabs.CombatTracker {
+  static PARTS = foundry.utils.mergeObject(super.PARTS, {
+    tracker: {
+      ...super.PARTS.tracker,
+      template: `systems/arkham-horror-rpg-fvtt/templates/combat/combat-tracker.hbs`
+    },
+    footer: {
+      template: `systems/arkham-horror-rpg-fvtt/templates/combat/combat-footer.hbs`
+    }
+  });
+
+  // Add our click actions (HandlebarsApplication routes data-action to DEFAULT_OPTIONS.actions)
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
+    actions: {
+      ...super.DEFAULT_OPTIONS.actions,
+      beginSideCombat: async function () { await this._beginSideCombat(); },
+      endSidePhase: async function () { await this._endSidePhase(); },
+    }
+  });
+
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+
+    const combat = this.viewed;
+    if (!combat) return context;
+
+    if (partId === "footer") {
+      const active = (await combat.getFlag(FLAG_SCOPE, FLAG_ACTIVE)) ?? null;
+      context.side = {
+        started: combat.started,
+        active,
+        activeLabel: active === "npcs" ? "NPCs" : "Investigators",
+        nextLabel: active === "npcs" ? "Investigators" : "NPCs",
+        canControl: combat.isOwner
+      };
+    }
+
+    if (partId === "tracker") {
+      const active = (await combat.getFlag(FLAG_SCOPE, FLAG_ACTIVE)) ?? null;
+      context.side = { active };
+
+      // In Foundry, `combat.turns` can be empty depending on turn/initiative prep.
+      // Fall back to combatants list so the tracker always shows entries.
+      const turns = (combat.turns?.length ? combat.turns : (combat.combatants?.contents ?? []));
+      const groups = [
+        { key: "investigators", label: "Investigators", isActive: active === "investigators", entries: [] },
+        { key: "npcs", label: "NPCs", isActive: active === "npcs", entries: [] },
+      ];
+
+      for (const combatant of turns) {
+        const actorType = combatant.actor?.type;
+        const groupKey = actorType === "npc" ? "npcs" : "investigators";
+        const group = groups.find(g => g.key === groupKey) ?? groups[0];
+
+        // Side-based highlighting: every combatant on the active side is marked "active".
+        const isActiveSide = !!combat.started && active === groupKey;
+
+        const dicepool = combatant.actor?.system?.dicepool;
+        const dicepoolValue = dicepool?.value;
+        const dicepoolMax = dicepool?.max;
+        const dicepoolDisplay = (dicepoolValue ?? dicepoolMax) != null
+          ? `${dicepoolValue ?? 0}/${dicepoolMax ?? "?"}`
+          : "";
+
+        group.entries.push({
+          id: combatant.id,
+          combatantId: combatant.id,
+          tokenId: combatant.token?.id ?? combatant.tokenId,
+          actorId: combatant.actor?.id,
+          name: combatant.name,
+          img: combatant.img,
+          active: isActiveSide,
+          defeated: combatant.defeated,
+          hidden: combatant.hidden,
+          dicepool: dicepoolDisplay,
+          css: [
+            isActiveSide ? "active" : "",
+            combatant.defeated ? "defeated" : "",
+            combatant.hidden ? "hidden" : "",
+          ].filter(Boolean).join(" "),
+          canPing: !!combatant.canPing,
+          isOwner: !!combatant.isOwner,
+        });
+      }
+
+      context.groupedTurns = groups;
+    }
+
+    return context;
+  }
+
+  async _beginSideCombat() {
+    const combat = this.viewed;
+    if (!combat?.isOwner) return;
+
+    // Use the standard Foundry flow: users add combatants explicitly (toggle token combat state).
+    // Starting side combat without combatants is allowed in core, but it doesn't make sense here.
+    if ((combat.combatants?.size ?? 0) === 0) {
+      ui.notifications.warn("Add combatants to the encounter first (toggle token combat state), then begin combat.");
+      return;
+    }
+
+    const first = await this._promptFirstSide();
+    if (!first) return;
+
+    await combat.setFlag(FLAG_SCOPE, FLAG_FIRST, first);
+    await combat.setFlag(FLAG_SCOPE, FLAG_ACTIVE, first);
+
+    // advances to round 1 / turn 1
+    await combat.startCombat();
+
+    // Re-render only what changed
+    await this.render({ parts: ["tracker", "footer"], force: true });
+    // Refresh side markers
+    // (Optional) If you later expose a system-level API, call it here.
+  }
+
+  async _endSidePhase() {
+    const combat = this.viewed;
+    if (!combat?.isOwner || !combat.started) return;
+
+    const active = (await combat.getFlag(FLAG_SCOPE, FLAG_ACTIVE)) ?? "investigators";
+    const next = active === "investigators" ? "npcs" : "investigators";
+
+    // Optional: when wrapping back to investigators, advance round
+    if (active === "npcs") {
+      await combat.update({ round: combat.round + 1 }); // keep turn as-is; we’re not using it for permission
+    }
+
+    await combat.setFlag(FLAG_SCOPE, FLAG_ACTIVE, next);
+
+    await this.render({ parts: ["tracker", "footer"], force: true });
+    // (Optional) If you later expose a system-level API, call it here.
+  }
+
+
+  async _promptFirstSide() {
+    const { DialogV2 } = foundry.applications.api;
+    return DialogV2.wait({
+      window: { title: "Begin Combat" },
+      content: `<p>Which side goes first?</p>`,
+      buttons: [
+        { action: "investigators", label: "Investigators", icon: "fa-solid fa-user" },
+        { action: "npcs",          label: "NPCs",          icon: "fa-solid fa-skull" }
+      ],
+      rejectClose: false
+    });
+  }
+}
+
+function isDicepoolUpdate(changed) {
+  const dicepool = changed?.system?.dicepool;
+  if (!dicepool) return false;
+  return Object.prototype.hasOwnProperty.call(dicepool, "value")
+    || Object.prototype.hasOwnProperty.call(dicepool, "max");
+}
+
+Hooks.on("updateActor", (actor, changed) => {
+  if (!isDicepoolUpdate(changed)) return;
+
+  const tracker = ui.combat;
+  const combat = tracker?.viewed;
+  if (!combat) return;
+
+  const combatants = combat.combatants?.contents ?? [];
+  if (!combatants.some(c => c.actorId === actor.id)) return;
+
+  tracker.render({ parts: ["tracker"], force: true });
+});

--- a/templates/combat/combat-footer.hbs
+++ b/templates/combat/combat-footer.hbs
@@ -1,0 +1,21 @@
+<nav class="combat-controls" data-tooltip-direction="UP">
+  {{#if side.canControl}}
+    {{#if side.started}}
+      <button type="button" class="combat-control combat-control-lg" data-action="endSidePhase" data-tooltip="End {{side.activeLabel}} Phase">
+        <i class="fa-solid fa-check" inert></i>
+        <span>End Phase</span>
+      </button>
+
+      <button type="button" class="combat-control combat-control-lg" data-action="endCombat" data-tooltip="End Combat">
+        <i class="fa-solid fa-flag-checkered" inert></i>
+        <span>End Combat</span>
+      </button>
+    {{else}}
+      <button type="button" class="combat-control combat-control-lg" data-action="beginSideCombat">
+        <i class="fa-solid fa-swords" inert></i>
+        <span>Begin Combat</span>
+      </button>
+    {{/if}}
+  {{/if}}
+</nav>
+

--- a/templates/combat/combat-tracker.hbs
+++ b/templates/combat/combat-tracker.hbs
@@ -1,0 +1,47 @@
+<ol class="combat-tracker" data-tab="combat" data-group="sidebar">
+  {{#each groupedTurns as |group|}}
+    <li class="combat-group-banner {{#if group.isActive}}is-active{{/if}}"
+        data-side="{{group.key}}">
+      <div class="flexrow">
+        <h5 class="combat-group-title flex1">{{group.label}}</h5>
+        {{#if @first}}
+          <div class="token-initiative" data-tooltip="Dice Pool">
+            <span class="initiative">Dice Pool</span>
+          </div>
+        {{/if}}
+      </div>
+      {{#if group.isActive}}
+        <span class="combat-group-subtitle">Active Side</span>
+      {{/if}}
+    </li>
+
+    {{#each group.entries as |turn|}}
+        <li class="combatant {{turn.css}}" data-combatant-id="{{turn.id}}" data-action="activateCombatant"
+          data-token-id="{{turn.tokenId}}"
+          data-actor-id="{{turn.actorId}}">
+
+        <img class="token-image" src="{{turn.img}}" alt="{{turn.name}}" loading="lazy">
+
+        <div class="token-name">
+          <strong class="name">{{turn.name}}</strong>
+          <div class="combatant-controls">
+            {{#if @root.user.isGM}}
+              <button type="button" class="inline-control combatant-control icon fa-solid fa-eye-slash {{#if turn.hidden}}active{{/if}}"
+                      data-action="toggleHidden"></button>
+              <button type="button" class="inline-control combatant-control icon fa-solid fa-skull {{#if turn.defeated}}active{{/if}}"
+                      data-action="toggleDefeated"></button>
+            {{/if}}
+            {{#unless @root.user.isGM}}
+              <button type="button" class="inline-control combatant-control icon fa-solid fa-arrows-to-eye"
+                      data-action="panToCombatant"></button>
+            {{/unless}}
+          </div>
+        </div>
+
+        <div class="token-initiative" data-tooltip="Dicepool">
+          <span class="initiative">{{turn.dicepool}}</span>
+        </div>
+      </li>
+    {{/each}}
+  {{/each}}
+</ol>


### PR DESCRIPTION
Combat Tracker for Arkham Horror, since the game doesn't use initiative and instead uses a "popcorn" method of side initiative with the GM determining "surprise" we needed a new combat tracker, this is version 1 and while mainly complete has not been styled or anything. The main focus of this initial commit is to mirror the functions of the Foundry combat tracker as closely as possible.  Including utilizing the css classes in our template files that it uses for its combat tracker this alleviated the need for any kind of css manipulation as we directly extend the inbuilt combat tracker and server our own tracker.hbs and footer.hbs file.  

Functions right now include.
1. Able to toggle combat state
2. Begin Combat (using native foundry function)
3. Choose the side that will start (Characters - Investigators) or NPCs
4. Highlights all players as active on each side, since according to game rules they can interleave their turns and choose who acts first on their turns.
5. Allows GM to "End Phase" highlighting the other phase and advancing the round when appropriate.
6. Ends Combat  (using native foundry function)
7. Maintains each combatants current dicepool value / dicepool max in the usual place that the initiative is in other systems.  Since one of the rules of Arkham that is highly suggested is that all players know the pools of all combatants during Structured Scenes.  This is not done by listening to the actor but rather by grabbing the "updateActor" hook and rerendering the tracker part.  Right now the hook is in the combat-tracker.mjs file at the bottom.

Pictures on build 13.0.7 ALPHA
<img width="975" height="793" alt="image" src="https://github.com/user-attachments/assets/829344b3-0b0d-4358-8964-7d7f496c0084" />

<img width="975" height="787" alt="image" src="https://github.com/user-attachments/assets/08abc6b6-6aac-41cb-95ea-73ec1219b515" />

<img width="975" height="794" alt="image" src="https://github.com/user-attachments/assets/4f257ec1-14ff-43cb-8a35-9cbf0fd2aff2" />

<img width="975" height="797" alt="image" src="https://github.com/user-attachments/assets/e6f502aa-b393-46be-ac42-2c466764923c" />

<img width="975" height="433" alt="image" src="https://github.com/user-attachments/assets/d8dcd625-2005-474d-be00-79a926a9603a" />
