### PR TITLE
Small enhancement to roll logic and roll card display

### DIFF
--- a/css/arkham-horror-rpg-fvtt.css
+++ b/css/arkham-horror-rpg-fvtt.css
@@ -638,15 +638,37 @@ form > nav > a.item.active {
 }
 
 li.chat-message.message {
-  border: 1px solid rgba(20, 16, 10, 0.5);
+  --ah-chat-bg-top: rgba(249, 240, 219, 0.96);
+  --ah-chat-bg-bottom: rgba(232, 219, 191, 0.94);
+  --ah-chat-border: rgba(20, 16, 10, 0.50);
+  --ah-chat-accent: #722A1C;
+  border: 1px solid var(--ah-chat-border);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(249, 240, 219, 0.96), rgba(232, 219, 191, 0.94)), repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.02) 0px, rgba(0, 0, 0, 0.02) 1px, rgba(255, 255, 255, 0) 3px, rgba(255, 255, 255, 0) 7px);
+  background: linear-gradient(180deg, var(--ah-chat-bg-top), var(--ah-chat-bg-bottom)), repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.02) 0px, rgba(0, 0, 0, 0.02) 1px, rgba(255, 255, 255, 0) 3px, rgba(255, 255, 255, 0) 7px);
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+}
+
+li.chat-message.message.whisper {
+  --ah-chat-bg-top: rgba(235, 241, 249, 0.95);
+  --ah-chat-bg-bottom: rgba(206, 218, 236, 0.93);
+  --ah-chat-border: rgba(54, 74, 115, 0.75);
+  --ah-chat-accent: rgba(66, 86, 132, 0.95);
+  --color-whisper-background: #dbe6f6;
+  --color-whisper-border: #3f527c;
+}
+
+li.chat-message.message.blind {
+  --ah-chat-bg-top: rgba(250, 236, 241, 0.95);
+  --ah-chat-bg-bottom: rgba(236, 205, 215, 0.93);
+  --ah-chat-border: rgba(124, 52, 73, 0.72);
+  --ah-chat-accent: rgba(144, 60, 82, 0.95);
+  --color-blind-background: #f2d7e0;
+  --color-blind-border: #7a3a50;
 }
 
 li.chat-message.message > header.message-header {
   padding: 8px 12px;
-  border-bottom: 1px solid #722A1C;
+  border-bottom: 1px solid var(--ah-chat-accent);
   background: transparent;
 }
 
@@ -1087,5 +1109,3 @@ li.chat-message.message > .message-content {
 .editor.prosemirror {
   height: 100%;
 }
-
-/*# sourceMappingURL=arkham-horror-rpg-fvtt.css.map */

--- a/module/rolls/skill-roll-workflow.mjs
+++ b/module/rolls/skill-roll-workflow.mjs
@@ -6,7 +6,7 @@ import {
     computeSkillOutcome,
     applyDicepoolCost,
 } from "../helpers/roll-engine.mjs";
-import { renderChatHtml, postChatMessage } from "../util/chat-utils.mjs";
+import { createArkhamHorrorChatCard } from "../util/chat-utils.mjs";
 
 
 export class SkillRollWorkflow {
@@ -151,10 +151,9 @@ export class SkillRollWorkflow {
 
   async post({ actor, state, outcome }) {
     const { template, chatData } = this.buildChat({ state, outcome });
-    const html = await renderChatHtml(template, chatData);
-    const message = await postChatMessage({ actor, html });
-    return { html, message, chatData };
-  }
+    // render and post chat message new method
+    return createArkhamHorrorChatCard( {actor, template, chatVars: chatData, flags: {"arkham-horror-rpg-fvtt": chatData}});
+    }
 
   /**
    * Convenience method: run end-to-end without an external orchestrator.

--- a/module/util/chat-utils.mjs
+++ b/module/util/chat-utils.mjs
@@ -2,11 +2,19 @@
 export async function renderChatHtml(templatePath, chatVars) {
   return foundry.applications.handlebars.renderTemplate(templatePath, chatVars);
 }
+// applies the roll mode to the chat data respecticting default foundry selectors and posts the message
+export async function applyChatModeAndPost(chatData, { rollMode = "roll" } = {}) {
+  const dataWithMode = ChatMessage.applyRollMode({ ...chatData }, rollMode);
+  return ChatMessage.create(dataWithMode);
+}
 
-// One place to handle top level chat message creation
-export async function postChatMessage({ actor, html }) {
-  return ChatMessage.create({
-    content: html,
-    speaker: ChatMessage.getSpeaker({ actor: actor }),
-  });
+// combines rendering and posting into a single function for Arkham Horror RPG chat cards
+// applies all chat data flags as well
+export async function createArkhamHorrorChatCard({ actor, template, chatVars, flags = {} }, options) {
+  const content = await renderChatHtml(template, chatVars);
+  return applyChatModeAndPost({ 
+    content, 
+    speaker: ChatMessage.getSpeaker({ actor: actor }), 
+    flags },
+     options);
 }

--- a/src/scss/global/_chat.scss
+++ b/src/scss/global/_chat.scss
@@ -293,17 +293,45 @@
 // -----------------------------------------------------------------------------
 
 li.chat-message.message {
-    border: 1px solid rgba(20, 16, 10, 0.50);
+    --ah-chat-bg-top: rgba(249, 240, 219, 0.96);
+    --ah-chat-bg-bottom: rgba(232, 219, 191, 0.94);
+    --ah-chat-border: rgba(20, 16, 10, 0.50);
+    --ah-chat-accent: #{$c-red};
+
+    border: 1px solid var(--ah-chat-border);
     border-radius: 12px;
     background:
-        linear-gradient(180deg, rgba(249, 240, 219, 0.96), rgba(232, 219, 191, 0.94)),
+        linear-gradient(180deg, var(--ah-chat-bg-top), var(--ah-chat-bg-bottom)),
         repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.02) 0px, rgba(0, 0, 0, 0.02) 1px, rgba(255, 255, 255, 0.00) 3px, rgba(255, 255, 255, 0.00) 7px);
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
+// Whisper messages (GM/private)
+li.chat-message.message.whisper {
+    --ah-chat-bg-top: rgba(235, 241, 249, 0.95);
+    --ah-chat-bg-bottom: rgba(206, 218, 236, 0.93);
+    --ah-chat-border: rgba(54, 74, 115, 0.75);
+    --ah-chat-accent: rgba(66, 86, 132, 0.95);
+
+    // Also align with Foundry's native variables (in case core styles reference them)
+    --color-whisper-background: #dbe6f6;
+    --color-whisper-border: #3f527c;
+}
+
+// Blind rolls (GM-only)
+li.chat-message.message.blind {
+    --ah-chat-bg-top: rgba(250, 236, 241, 0.95);
+    --ah-chat-bg-bottom: rgba(236, 205, 215, 0.93);
+    --ah-chat-border: rgba(124, 52, 73, 0.72);
+    --ah-chat-accent: rgba(144, 60, 82, 0.95);
+
+    --color-blind-background: #f2d7e0;
+    --color-blind-border: #7a3a50;
+}
+
 li.chat-message.message > header.message-header {
     padding: 8px 12px;
-    border-bottom: 1px solid $c-red;
+    border-bottom: 1px solid var(--ah-chat-accent);
     background: transparent;
 }
 


### PR DESCRIPTION
This PR is adding the ability to respect foundry's native selectors "GM Roll" "Blind Roll" "Self Roll" to the roll logic, it also simplifies the roll call allowing for one function call from the various "workflow" classes.

There is additional scss to handle and try to keep to foundry's default blue/rose gm/blind roll colors so it is clear what can be seen by all players.

Finally with this small refactor to include the roll mode, we have also prepared the ground work for the ability to create action buttons directly on roll cards (reroll, apply Injury/Trauma to actor) as we are now passing the chatVars through to the flags so that they persist on the chat message.  Top is GM roll, middle is blind roll, bottom is self roll.  console open to show flags persisting on the ChatMessage object.

<img width="975" height="891" alt="image" src="https://github.com/user-attachments/assets/8eba331d-edb5-4308-968e-df126b26e67f" />
