### PR TITLE
Dice Result mod added

### DIFF
--- a/module/apps/dice-roll-app.mjs
+++ b/module/apps/dice-roll-app.mjs
@@ -31,6 +31,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
         diceToUse: 0,
         penalty: 0,
         bonusDice: 0,
+        resultModifier: 0,
         successesNeeded: 0,
 
         rollWithAdvantage: false,
@@ -94,6 +95,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
     this.rollState.diceToUse = 0;
     this.rollState.bonusDice = 0;
     this.rollState.penalty = 0;
+    this.rollState.resultModifier = 0;
     this.rollState.successesNeeded = 0;
   }
 
@@ -121,6 +123,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
         diceToUse: this.rollState.diceToUse,
         penalty: this.rollState.penalty,
         bonus_dice: this.rollState.bonusDice, // bonus_dice match form field name so this populates 0 correctly now
+        resultModifier: this.rollState.resultModifier,
         successesNeeded: this.rollState.successesNeeded,
         rollWithAdvantage: this.rollState.rollWithAdvantage,
         rollWithDisadvantage: this.rollState.rollWithDisadvantage,
@@ -162,6 +165,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
     this.rollState.diceToUse = Number.parseInt(form.diceToUse.value) || 0;
     this.rollState.penalty = Number.parseInt(form.penalty.value) || 0;
     this.rollState.bonusDice = Number.parseInt(form.bonus_dice.value) || 0;
+    this.rollState.resultModifier = Number.parseInt(form.resultModifier?.value) || 0;
     this.rollState.successesNeeded = Number.parseInt(form.difficulty.value) || 0;
 
     // Advantage / disadvantage selector logic (same as original intent)

--- a/module/rolls/skill-roll-workflow.mjs
+++ b/module/rolls/skill-roll-workflow.mjs
@@ -18,6 +18,7 @@ export class SkillRollWorkflow {
       diceToUse: state.diceToUse,
       penalty: state.penalty,
       bonusDice: state.bonusDice,
+      resultModifier: state.resultModifier,
       rollWithAdvantage: state.rollWithAdvantage,
       rollWithDisadvantage: state.rollWithDisadvantage,
     });
@@ -88,6 +89,7 @@ export class SkillRollWorkflow {
       successOn: plan.successOn,
       penalty: plan.penalty,
       successesNeeded: state.successesNeeded,
+      resultModifier: plan.resultModifier,
     });
 
     outcome = { ...outcome, ...this.processWeapon({ state, outcome }) };
@@ -100,6 +102,7 @@ export class SkillRollWorkflow {
       horrorDiceToRoll: plan.horrorDiceToRoll,
       penalty: plan.penalty,
       bonusDice: plan.bonusDice,
+      resultModifier: plan.resultModifier,
       successesNeeded: Number.parseInt(state.successesNeeded) || 0,
       rollWithAdvantage: plan.rollWithAdvantage,
       rollWithDisadvantage: plan.rollWithDisadvantage,
@@ -135,6 +138,7 @@ export class SkillRollWorkflow {
       isSuccess: outcome.isSuccess,
       penalty: outcome.penalty,
       bonusDice: outcome.bonusDice,
+      resultModifier: outcome.resultModifier,
       successesNeeded: outcome.successesNeeded,
       rollWithAdvantage: outcome.rollWithAdvantage,
       rollWithDisadvantage: outcome.rollWithDisadvantage,

--- a/templates/chat/roll-result.hbs
+++ b/templates/chat/roll-result.hbs
@@ -48,6 +48,13 @@
                 <span class="arkham-roll-flag is-dis">Disadvantage</span>
             {{/if}}
 
+            {{#if (gte penalty 1)}}
+                <span class="arkham-roll-flag is-diff">Penalty -{{penalty}}</span>
+            {{/if}}
+            {{#if (gte resultModifier 1)}}
+                <span class="arkham-roll-flag is-diff">Result +{{resultModifier}}</span>
+            {{/if}}
+
             <span class="arkham-roll-flag is-diff">
                 {{#if (eq successesNeeded 1)}}Normal{{else if (eq successesNeeded 2)}}Difficult{{else if (eq successesNeeded 3)}}Very Difficult{{else}}Difficulty {{successesNeeded}}{{/if}}
             </span>

--- a/templates/dice-roll-app/dialog.hbs
+++ b/templates/dice-roll-app/dialog.hbs
@@ -25,6 +25,10 @@
         <input type="number" id="penalty" name="penalty" value="{{penalty}}" min="0">
     </div>
     <div class="form-group">
+        <label for="result-modifier">Result Modifier</label>
+        <input type="number" id="result-modifier" name="resultModifier" value="{{resultModifier}}" min="0" max="6" step="1">
+    </div>
+    <div class="form-group">
         <label for="difficulty">Difficulty</label>
         <select id="difficulty" name="difficulty">
             <option value="1" {{#if (eq successesNeeded 1)}}selected{{/if}}>Normal (1)</option>


### PR DESCRIPTION
Adds a result modifier to the dice roll app and flows that through every layer.
One small bug(?) fix around how successOn was being modified by penalty but then also being subtracted from final result.  Potentially causing a "silent" miscount of successes that were 1 off.  Changed failure to count all failures not just 1's, we can rename / also deliver this in another way.  We also clamp to 1-6 regardless of entry into penalty and result mod.  Added new flags to show this data.  Future we will potentially do a dropdown from the result to show original vs not.  nat1/nat6 etc.

<img width="292" height="678" alt="image" src="https://github.com/user-attachments/assets/e8ad7d7f-b0dd-44de-8970-e32e8e8eabfe" />

Actual roll for last chat message above:
<img width="975" height="866" alt="image" src="https://github.com/user-attachments/assets/35bb7ac0-bd35-440d-b175-0641d29d962e" />




