### PR TITLE
v1 injury and trauma rolls

### DIFF
--- a/css/arkham-horror-rpg-fvtt.css
+++ b/css/arkham-horror-rpg-fvtt.css
@@ -714,6 +714,48 @@ li.chat-message.message > .message-content {
   margin-top: 0;
 }
 
+.arkham-injury-trauma-card .arkham-roll-kind.is-injury {
+  border-color: #722A1C;
+  background: rgba(114, 42, 28, 0.07);
+  color: #722A1C;
+}
+
+.arkham-injury-trauma-card .arkham-roll-kind.is-trauma {
+  border-color: rgba(0, 0, 0, 0.75);
+  background: rgba(0, 0, 0, 0.06);
+  color: rgba(0, 0, 0, 0.88);
+}
+
+.arkham-injury-trauma-banner {
+  margin: 8px 2px 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  text-align: center;
+  font-weight: 900;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  border: 1px solid rgba(20, 16, 10, 0.45);
+  background: repeating-linear-gradient(-12deg, rgba(255, 255, 255, 0.1) 0px, rgba(255, 255, 255, 0.1) 2px, rgba(255, 255, 255, 0) 2px, rgba(255, 255, 255, 0) 6px), rgba(30, 30, 30, 0.08);
+  color: rgba(20, 16, 10, 0.95);
+  font-family: "Voltaire", sans-serif;
+  font-size: 14px;
+  line-height: 1.2;
+}
+
+.arkham-injury-trauma-description {
+  margin: 0 2px 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(20, 16, 10, 0.14);
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.arkham-injury-trauma-description p {
+  margin: 0;
+}
+
 .journal-page-content {
   font-family: "Lusitana", serif;
   text-align: justify;
@@ -1151,5 +1193,3 @@ li.chat-message.message > .message-content {
 .editor.prosemirror {
   height: 100%;
 }
-
-/*# sourceMappingURL=arkham-horror-rpg-fvtt.css.map */

--- a/module/apps/injury-trauma-roll-app.mjs
+++ b/module/apps/injury-trauma-roll-app.mjs
@@ -1,0 +1,92 @@
+import { InjuryTraumaWorkflow } from "../rolls/injury-trauma-workflow.mjs";
+
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+
+export class InjuryTraumaRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
+  constructor(options = {}) {
+    super(options);
+
+    this.actor = options.actor;
+
+    this.rollState = {
+      rollKind: options.rollKind ?? "injury",
+      modifier: Number.parseInt(options.modifier) || 0,
+    };
+
+    InjuryTraumaRollApp.instance = this;
+  }
+
+  static DEFAULT_OPTIONS = {
+    id: "injury-trauma-roll-app",
+    // Include dice-roll-app class so we inherit the same window-content background styles.
+    classes: ["dialog", "injury-trauma-roll-app", "dice-roll-app"],
+    tag: "div",
+    window: {
+      frame: true,
+      title: "Injury / Trauma Roll",
+      icon: "fa-solid fa-dice-d6",
+      positioned: true,
+      resizable: false,
+    },
+    position: {
+      width: 360,
+      height: "auto",
+    },
+    actions: {
+      clickedRoll: this.#handleClickedRoll,
+    },
+  };
+
+  static PARTS = {
+    dialog: {
+      template: "systems/arkham-horror-rpg-fvtt/templates/injury-trauma-roll-app/dialog.hbs",
+      scrollable: [""],
+    },
+  };
+
+  setOptions(options = {}) {
+    if (options.actor) this.actor = options.actor;
+    if (options.rollKind) this.rollState.rollKind = options.rollKind;
+    if (options.modifier !== undefined) this.rollState.modifier = Number.parseInt(options.modifier) || 0;
+  }
+
+  static getInstance(options = {}) {
+    if (!InjuryTraumaRollApp.instance) {
+      InjuryTraumaRollApp.instance = new InjuryTraumaRollApp(options);
+    }
+    const instance = InjuryTraumaRollApp.instance;
+    instance.setOptions(options);
+    return instance;
+  }
+
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+
+    return {
+      ...context,
+      actor: this.actor,
+      rollKind: this.rollState.rollKind,
+      modifier: this.rollState.modifier,
+    };
+  }
+
+  static async #handleClickedRoll(event, target) {
+    this.clickedRollCallback(event, target);
+  }
+
+  async clickedRollCallback(event, target) {
+    event.preventDefault();
+
+    const form = target.form;
+    const rollKind = String(form.rollKind?.value ?? "injury");
+    const modifier = Number.parseInt(form.modifier?.value) || 0;
+
+    const workflow = new InjuryTraumaWorkflow();
+    await workflow.run({
+      actor: this.actor,
+      state: { rollKind, modifier },
+    });
+
+    this.close();
+  }
+}

--- a/module/rolls/injury-trauma-workflow.mjs
+++ b/module/rolls/injury-trauma-workflow.mjs
@@ -1,0 +1,274 @@
+import { rollD6 } from "../helpers/roll-engine.mjs";
+import { createArkhamHorrorChatCard } from "../util/chat-utils.mjs";
+
+const SYSTEM_ID = "arkham-horror-rpg-fvtt";
+
+const FALLBACK_TABLES = {
+  trauma: {
+    standard: [
+      { min: 1, max: 2, rangeLabel: "1–2", result: "Subtle Strangeness" },
+      { min: 3, max: 3, rangeLabel: "3", result: "Shocked" },
+      { min: 4, max: 4, rangeLabel: "4", result: "Stunned" },
+      { min: 5, max: 7, rangeLabel: "5–7", result: "Overcome by Horror" },
+      { min: 8, max: 10, rangeLabel: "8–10", result: "Mind Undone" },
+      { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", result: "Lost Forever" },
+    ],
+    noPersonality: [
+      { min: 1, max: 2, rangeLabel: "1–2", result: "Subtle Strangeness" },
+      { min: 3, max: 4, rangeLabel: "3–4", result: "Shocked" },
+      { min: 5, max: 7, rangeLabel: "5–7", result: "Stunned" },
+      { min: 8, max: 10, rangeLabel: "8–10", result: "Mind Undone" },
+      { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", result: "Lost Forever" },
+    ],
+  },
+  injury: [
+    { min: 1, max: 1, rangeLabel: "1", result: "Heavy Blow" },
+    { min: 2, max: 2, rangeLabel: "2", result: "Slowed" },
+    { min: 3, max: 3, rangeLabel: "3", result: "Nasty Cut" },
+    { min: 4, max: 4, rangeLabel: "4", result: "Concussed" },
+    { min: 5, max: 5, rangeLabel: "5", result: "Injured Arm" },
+    { min: 6, max: 6, rangeLabel: "6", result: "Injured Leg" },
+    { min: 7, max: 7, rangeLabel: "7", result: "Loss of a Sense" },
+    { min: 8, max: 8, rangeLabel: "8", result: "Severely Injured" },
+    { min: 9, max: 9, rangeLabel: "9", result: "Comatose" },
+    { min: 10, max: 10, rangeLabel: "10", result: "Dire" },
+    { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", result: "Dead" },
+  ],
+};
+
+const warnOnceKeys = new Set();
+
+function normalizeKind(kind) {
+  const k = String(kind ?? "").toLowerCase();
+  if (k === "injury" || k === "trauma") return k;
+  return "injury";
+}
+
+function lookupFallbackEntry(kind, traumaVariant, total) {
+  const t = Number(total);
+  if (kind === "trauma") {
+    const entries = FALLBACK_TABLES.trauma[traumaVariant] ?? FALLBACK_TABLES.trauma.standard;
+    return entries.find(e => t >= e.min && t <= e.max) ?? null;
+  }
+  const entries = FALLBACK_TABLES.injury;
+  return entries.find(e => t >= e.min && t <= e.max) ?? null;
+}
+
+function warnOnce(key, message) {
+  if (warnOnceKeys.has(key)) return;
+  warnOnceKeys.add(key);
+
+  // Surface to the GM in the UI (but don't spam players).
+  try {
+    if (game?.user?.isGM && ui?.notifications?.warn) {
+      ui.notifications.warn(message);
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  // eslint-disable-next-line no-console
+  console.warn(message);
+}
+
+function getActorCategory(actor) {
+  const type = actor?.type;
+  if (type === "npc") return "npc";
+  return "character";
+}
+
+function getTraumaVariantSetting() {
+  const v = String(game.settings.get(SYSTEM_ID, "characterTraumaTableVariant") ?? "standard");
+  return v === "noPersonality" ? "noPersonality" : "standard";
+}
+
+function getConfiguredTableId({ actorCategory, kind, traumaVariant }) {
+  if (kind === "injury") {
+    if (actorCategory === "npc") return game.settings.get(SYSTEM_ID, "npcInjuryTable") || "";
+    return game.settings.get(SYSTEM_ID, "characterInjuryTable") || "";
+  }
+
+  // trauma (uses existing "horror" settings)
+  if (actorCategory === "npc") return game.settings.get(SYSTEM_ID, "npcHorrorTable") || "";
+  if (traumaVariant === "noPersonality") return game.settings.get(SYSTEM_ID, "characterHorrorTableNoPersonality") || "";
+  return game.settings.get(SYSTEM_ID, "characterHorrorTable") || "";
+}
+
+function getConfiguredCharacterFallbackTableId({ kind, traumaVariant }) {
+  if (kind === "injury") return game.settings.get(SYSTEM_ID, "characterInjuryTable") || "";
+  if (traumaVariant === "noPersonality") return game.settings.get(SYSTEM_ID, "characterHorrorTableNoPersonality") || "";
+  return game.settings.get(SYSTEM_ID, "characterHorrorTable") || "";
+}
+
+function resolveFromRollTableByTotal({ rollTable, total }) {
+  if (!rollTable) return null;
+  const results = Array.from(rollTable.results ?? []);
+  if (results.length === 0) return null;
+
+  const t = Number(total);
+  const match = results.find(r => {
+    const min = Number(r?.range?.[0]);
+    const max = Number(r?.range?.[1]);
+    if (!Number.isFinite(min) || !Number.isFinite(max)) return false;
+    return t >= min && t <= max;
+  });
+  if (match) {
+    const [min, max] = match.range;
+    const rangeLabel = min === max ? String(min) : `${min}–${max}`;
+    const name = String(match.name ?? "").trim();
+    const description = String(match.description ?? "").trim();
+    if (!name) {
+      return { rangeLabel, resultName: "", resultDescription: description, missingName: true };
+    }
+    return { rangeLabel, resultName: name, resultDescription: description };
+  }
+
+  // Safe hybrid overflow:
+  // If total is above the maximum range, treat the *single-value* top entry (max==min==tableMax) as "tableMax+".
+  let tableMax = Number.NEGATIVE_INFINITY;
+  for (const r of results) {
+    const max = Number(r?.range?.[1]);
+    if (Number.isFinite(max) && max > tableMax) tableMax = max;
+  }
+  if (!Number.isFinite(tableMax)) return null;
+
+  if (t > tableMax) {
+    const topSingle = results.find(r => Number(r?.range?.[0]) === tableMax && Number(r?.range?.[1]) === tableMax);
+    if (topSingle) {
+      const name = String(topSingle.name ?? "").trim();
+      const description = String(topSingle.description ?? "").trim();
+      if (!name) {
+        return {
+          rangeLabel: `${tableMax}+`,
+          resultName: "",
+          resultDescription: description,
+          usedOverflowAssumption: true,
+          tableMax,
+          missingName: true,
+        };
+      }
+      return {
+        rangeLabel: `${tableMax}+`,
+        resultName: name,
+        resultDescription: description,
+        usedOverflowAssumption: true,
+        tableMax,
+      };
+    }
+  }
+
+  return null;
+}
+
+export class InjuryTraumaWorkflow {
+  async execute({ actor, state }) {
+    const roll = await rollD6({ actor, numDice: 1 });
+    const dieResult = Number(roll.results?.[0] ?? 0);
+
+    const rollKind = normalizeKind(state?.rollKind);
+    const modifier = Number.parseInt(state?.modifier) || 0;
+    const total = dieResult + modifier;
+
+    const actorCategory = getActorCategory(actor);
+    const traumaVariant = getTraumaVariantSetting();
+
+    const primaryTableId = getConfiguredTableId({ actorCategory, kind: rollKind, traumaVariant });
+    const characterFallbackTableId = actorCategory === "npc"
+      ? getConfiguredCharacterFallbackTableId({ kind: rollKind, traumaVariant })
+      : "";
+
+    let resolved = null;
+
+    if (primaryTableId) {
+      const table = game.tables.get(primaryTableId);
+      resolved = resolveFromRollTableByTotal({ rollTable: table, total });
+      if (resolved?.missingName) {
+        warnOnce(
+          `${SYSTEM_ID}|missingName|${primaryTableId}`,
+          `[${SYSTEM_ID}] RollTable '${table?.name ?? primaryTableId}' has a matching range but empty result name. Set the RollTable Result Name, or the system will fall back to built-in tables.`
+        );
+        resolved = null;
+      }
+      if (resolved?.usedOverflowAssumption) {
+        warnOnce(
+          `${SYSTEM_ID}|overflow|${primaryTableId}`,
+          `[${SYSTEM_ID}] RollTable '${table?.name ?? primaryTableId}' maxes at ${resolved.tableMax}; treating top entry as ${resolved.tableMax}+ for total ${total}.`
+        );
+      }
+    }
+
+    // If NPC-specific table isn't set/usable, fall back to the configured character table.
+    if (!resolved && actorCategory === "npc" && characterFallbackTableId) {
+      const table = game.tables.get(characterFallbackTableId);
+      resolved = resolveFromRollTableByTotal({ rollTable: table, total });
+      if (resolved?.missingName) {
+        warnOnce(
+          `${SYSTEM_ID}|missingName|${characterFallbackTableId}`,
+          `[${SYSTEM_ID}] RollTable '${table?.name ?? characterFallbackTableId}' has a matching range but empty result name. Set the RollTable Result Name, or the system will fall back to built-in tables.`
+        );
+        resolved = null;
+      }
+      if (resolved?.usedOverflowAssumption) {
+        warnOnce(
+          `${SYSTEM_ID}|overflow|${characterFallbackTableId}`,
+          `[${SYSTEM_ID}] RollTable '${table?.name ?? characterFallbackTableId}' maxes at ${resolved.tableMax}; treating top entry as ${resolved.tableMax}+ for total ${total}.`
+        );
+      }
+    }
+
+    // Built-in fallback tables.
+    const fallbackEntry = lookupFallbackEntry(rollKind, traumaVariant, total);
+    const entry = resolved
+      ? { rangeLabel: resolved.rangeLabel, resultName: resolved.resultName, resultDescription: resolved.resultDescription }
+      : { rangeLabel: fallbackEntry?.rangeLabel, resultName: fallbackEntry?.result, resultDescription: "" };
+
+    return {
+      rollKind,
+      dieResult,
+      modifier,
+      total,
+      tableRange: entry?.rangeLabel ?? "—",
+      tableResultName: entry?.resultName ?? "No matching table entry",
+      tableResultDescription: entry?.resultDescription ?? "",
+    };
+  }
+
+  buildChat({ actor, outcome }) {
+    const template = `systems/${SYSTEM_ID}/templates/chat/injury-trauma-roll-card.hbs`;
+
+    const rollKindLabel = outcome.rollKind === "trauma" ? "Trauma" : "Injury";
+
+    const chatData = {
+      actorName: actor?.name ?? "",
+      rollKind: outcome.rollKind,
+      rollKindLabel,
+      dieResult: outcome.dieResult,
+      modifier: outcome.modifier,
+      total: outcome.total,
+      tableRange: outcome.tableRange,
+      tableResultName: outcome.tableResultName,
+      tableResultDescription: outcome.tableResultDescription,
+    };
+
+    return { template, chatData };
+  }
+
+  async post({ actor, outcome }) {
+    const { template, chatData } = this.buildChat({ actor, outcome });
+
+    const flags = {
+      [SYSTEM_ID]: {
+        ...chatData,
+        rollCategory: "injury-trauma",
+      },
+    };
+
+    return createArkhamHorrorChatCard({ actor, template, chatVars: chatData, flags });
+  }
+
+  async run({ actor, state }) {
+    const outcome = await this.execute({ actor, state });
+    const posted = await this.post({ actor, outcome });
+    return { outcome, ...posted };
+  }
+}

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -3,6 +3,7 @@ const { HandlebarsApplicationMixin } = foundry.applications.api
 const { TextEditor, DragDrop } = foundry.applications.ux
 import { ArkhamHorrorItem } from "../documents/item.mjs";
 import { DiceRollApp } from '../apps/dice-roll-app.mjs';
+import { InjuryTraumaRollApp } from '../apps/injury-trauma-roll-app.mjs';
 
 export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
@@ -25,7 +26,8 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
             clickSkill: this.#handleSkillClicked,
             clickWeaponReload: this.#handleWeaponReload,
             clickedRefreshDicePool: this.#handleClickedRefreshDicePool,
-            clickedRollWithWeapon: this.#handleClickedRollWithWeapon
+            clickedRollWithWeapon: this.#handleClickedRollWithWeapon,
+            clickedInjuryTraumaRoll: this.#handleClickedInjuryTraumaRoll
         },
         form: {
             submitOnChange: true
@@ -557,5 +559,10 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
         } else {
             console.error(`Item with ID ${itemId} not found on actor.`);
         }
+    }
+
+    static async #handleClickedInjuryTraumaRoll(event, target) {
+        event.preventDefault();
+        InjuryTraumaRollApp.getInstance({ actor: this.actor, rollKind: "injury", modifier: 0 }).render(true);
     }
 }

--- a/module/sheets/npc-sheet.mjs
+++ b/module/sheets/npc-sheet.mjs
@@ -3,6 +3,7 @@ const { HandlebarsApplicationMixin } = foundry.applications.api
 const { TextEditor, DragDrop } = foundry.applications.ux
 import { ArkhamHorrorItem } from "../documents/item.mjs";
 import { DiceRollApp } from '../apps/dice-roll-app.mjs';
+import { InjuryTraumaRollApp } from '../apps/injury-trauma-roll-app.mjs';
 
 export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     #dragDrop // Private field to hold dragDrop handlers
@@ -25,7 +26,8 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
             clickSkill: this.#handleSkillClicked,
             clickWeaponReload: this.#handleWeaponReload,
             clickedRefreshDicePool: this.#handleClickedRefreshDicePool,
-            clickedRollWithWeapon: this.#handleClickedRollWithWeapon
+            clickedRollWithWeapon: this.#handleClickedRollWithWeapon,
+            clickedInjuryTraumaRoll: this.#handleClickedInjuryTraumaRoll
         },
         form: {
             submitOnChange: true
@@ -197,6 +199,11 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
     static async #handleClickedClearDicePool(event, target) {
         event.preventDefault();
         this.actor.update({ 'system.dicepool.value': 0 });
+    }
+
+    static async #handleClickedInjuryTraumaRoll(event, target) {
+        event.preventDefault();
+        InjuryTraumaRollApp.getInstance({ actor: this.actor, rollKind: "injury", modifier: 0 }).render(true);
     }
 
     static async #handleEditItem(event, target) {

--- a/module/util/configuration.mjs
+++ b/module/util/configuration.mjs
@@ -34,6 +34,7 @@ export function setupConfiguration() {
         type: String,
         choices: () => {
             const tables = {};
+            tables[""] = "";
             for (const table of game.tables) {
                 tables[table.id] = table.name;
             }
@@ -41,14 +42,48 @@ export function setupConfiguration() {
         },
         default: ""
     });
+    
+    game.settings.register("arkham-horror-rpg-fvtt", "characterTraumaTableVariant", {
+        name: "Character Trauma Table Variant",
+        hint: "Choose which character trauma table to use when rolling trauma.",
+        scope: "world",
+        config: true,
+        type: String,
+        choices: {
+            standard: "Standard",
+            noPersonality: "No-Personality",
+        },
+        default: "standard"
+    });
+    
     game.settings.register("arkham-horror-rpg-fvtt", "characterHorrorTable", {
-        name: "Character Horror Table",
-        hint: "Used for rolling horror",
+        name: "Character Trauma Table",
+        hint: "Used for rolling trauma",
         scope: "world",
         config: true,
         type: String,
         choices: () => {
             const tables = {};
+            tables[""] = "";
+            for (const table of game.tables) {
+                tables[table.id] = table.name;
+            }
+            return tables;
+        },
+        default: ""
+    });
+
+
+
+    game.settings.register("arkham-horror-rpg-fvtt", "characterHorrorTableNoPersonality", {
+        name: "Character Trauma Table (No-Personality)",
+        hint: "Optional alternate trauma table with fewer entries (no personality trait effects).",
+        scope: "world",
+        config: true,
+        type: String,
+        choices: () => {
+            const tables = {};
+            tables[""] = "";
             for (const table of game.tables) {
                 tables[table.id] = table.name;
             }
@@ -65,6 +100,7 @@ export function setupConfiguration() {
         type: String,
         choices: () => {
             const tables = {};
+            tables[""] = "";
             for (const table of game.tables) {
                 tables[table.id] = table.name;
             }
@@ -73,13 +109,14 @@ export function setupConfiguration() {
         default: ""
     });
     game.settings.register("arkham-horror-rpg-fvtt", "npcHorrorTable", {
-        name: "NPC Horror Table",
-        hint: "Used for rolling horror",
+        name: "NPC Trauma Table",
+        hint: "Used for rolling trauma",
         scope: "world",
         config: true,
         type: String,
         choices: () => {
             const tables = {};
+            tables[""] = "";
             for (const table of game.tables) {
                 tables[table.id] = table.name;
             }

--- a/src/scss/global/_chat.scss
+++ b/src/scss/global/_chat.scss
@@ -358,3 +358,51 @@ li.chat-message.message > .message-content {
 .arkham-roll-card {
     margin-top: 0;
 }
+
+// -----------------------------------------------------------------------------
+// Injury / Trauma roll card
+// -----------------------------------------------------------------------------
+
+.arkham-injury-trauma-card .arkham-roll-kind.is-injury {
+    border-color: $c-red;
+    background: rgba($c-red, 0.07);
+    color: $c-red;
+}
+
+.arkham-injury-trauma-card .arkham-roll-kind.is-trauma {
+    border-color: rgba(0, 0, 0, 0.75);
+    background: rgba(0, 0, 0, 0.06);
+    color: rgba(0, 0, 0, 0.88);
+}
+
+.arkham-injury-trauma-banner {
+    margin: 8px 2px 10px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    text-align: center;
+    font-weight: 900;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    border: 1px solid rgba(20, 16, 10, 0.45);
+    background:
+        repeating-linear-gradient(-12deg, rgba(255, 255, 255, 0.10) 0px, rgba(255, 255, 255, 0.10) 2px, rgba(255, 255, 255, 0.00) 2px, rgba(255, 255, 255, 0.00) 6px),
+        rgba(30, 30, 30, 0.08);
+    color: rgba(20, 16, 10, 0.95);
+    font-family: "Voltaire", sans-serif;
+    font-size: 14px;
+    line-height: 1.2;
+}
+
+.arkham-injury-trauma-description {
+    margin: 0 2px 10px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid rgba(20, 16, 10, 0.14);
+    background: rgba(255, 255, 255, 0.10);
+    font-size: 12px;
+    line-height: 1.25;
+}
+
+.arkham-injury-trauma-description p {
+    margin: 0;
+}

--- a/templates/actor/parts/character-injuries.hbs
+++ b/templates/actor/parts/character-injuries.hbs
@@ -1,5 +1,10 @@
 <fieldset>
-    <legend>INJURIES &amp; TRAUMA</legend>
+    <legend>
+        INJURIES &amp; TRAUMA
+        <a class='item-control' data-action="clickedInjuryTraumaRoll" title="Roll Injury/Trauma">
+            <i class="fa-solid fa-dice"></i>
+        </a>
+    </legend>
     {{#each injuries as |injury|}}
     <div class="injury-entry">
         <div>

--- a/templates/chat/injury-trauma-roll-card.hbs
+++ b/templates/chat/injury-trauma-roll-card.hbs
@@ -1,0 +1,38 @@
+<section class="arkham-roll-card arkham-injury-trauma-card" data-roll-category="injury-trauma" data-roll-kind="{{rollKind}}">
+  <header class="arkham-roll-header">
+    <div class="arkham-roll-heading">
+      <span class="arkham-roll-kind {{#if (eq rollKind "injury")}}is-injury{{else}}is-trauma{{/if}}">{{rollKindLabel}}</span>
+    </div>
+  </header>
+
+  <div class="arkham-roll-banner arkham-injury-trauma-banner">
+    {{tableResultName}}
+  </div>
+
+  {{#if tableResultDescription}}
+    <div class="arkham-injury-trauma-description">
+      {{{tableResultDescription}}}
+    </div>
+  {{/if}}
+
+  <div class="arkham-roll-results">
+    <div class="arkham-roll-meta">
+      <div class="arkham-meta-row">
+        <span class="arkham-meta-label">Die</span>
+        <span class="arkham-meta-value">{{dieResult}}</span>
+      </div>
+      <div class="arkham-meta-row">
+        <span class="arkham-meta-label">Modifier</span>
+        <span class="arkham-meta-value">{{modifier}}</span>
+      </div>
+      <div class="arkham-meta-row">
+        <span class="arkham-meta-label">Total</span>
+        <span class="arkham-meta-value">{{total}}</span>
+      </div>
+      <div class="arkham-meta-row">
+        <span class="arkham-meta-label">Table</span>
+        <span class="arkham-meta-value">{{tableRange}}</span>
+      </div>
+    </div>
+  </div>
+</section>

--- a/templates/injury-trauma-roll-app/dialog.hbs
+++ b/templates/injury-trauma-roll-app/dialog.hbs
@@ -1,0 +1,20 @@
+<form class="roll-dialog-container scrollable">
+  <div class="form-group">
+    <label>Roll Type</label>
+    <select name="rollKind">
+      <option value="injury" {{#if (eq rollKind "injury")}}selected{{/if}}>Injury</option>
+      <option value="trauma" {{#if (eq rollKind "trauma")}}selected{{/if}}>Trauma</option>
+    </select>
+  </div>
+
+  <div class="form-group">
+    <label>Modifier</label>
+    <input type="number" name="modifier" value="{{modifier}}" step="1" />
+  </div>
+
+  <p class="arkham-horror-hint">Total = 1d6 + modifier</p>
+
+  <footer class="dialog-footer">
+    <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> Roll</button>
+  </footer>
+</form>

--- a/templates/npc/parts/npc-main.hbs
+++ b/templates/npc/parts/npc-main.hbs
@@ -24,7 +24,12 @@
     </div>
     <div class="grid grid2-col">
         <fieldset>
-            <legend>INJURIES &amp; TRAUMA</legend>
+            <legend>
+                INJURIES &amp; TRAUMA
+                <a class='item-control' data-action="clickedInjuryTraumaRoll" title="Roll Injury/Trauma">
+                    <i class="fa-solid fa-dice"></i>
+                </a>
+            </legend>
             {{#each injuries as |injury|}}
             <div class="injury-entry">
                 <div>


### PR DESCRIPTION
This is a very stripped down version of an injury / trauma roll implementation, there is now a dice icon on the injury trauma part of both the NPC and Character sheets.  This allows a dialog that will accept a selector of injury/trauma and a manually entered modifier, there is no automation here.  It will then look at the game.settings to see if there is an appropriate world table assigned for the result.  If there is it will provide both the name and description to a chat card.  If there is not an assigned table we fall back to an internal representation which only provides the name of the injury or trauma and no further details on description, effect etc.  It also therefore doesn't apply an embedded document or anything like that, but does provide this critical functionality.  Added an additional setting to allow GM's to hold both standard trauma tables and "no-personality" tables (if they are running starter set or pregen characters)

Showing NPC RollTable filled out and assigned and dropping to the chat card.
<img width="975" height="794" alt="image" src="https://github.com/user-attachments/assets/5b5f948c-5449-4312-802a-fd614cd32058" />

Showing a Character roll with no RollTable assigned falling back to the system interpretation.
<img width="975" height="716" alt="image" src="https://github.com/user-attachments/assets/4aa691bf-956e-444e-8597-959796bdfce8" />

We also do error handling for the rollTable and fall back if the table is malformed, or in this case if there is a maximum value that isn't 7-999 or something similar to equate to 7+ on the printed table.

<img width="975" height="777" alt="image" src="https://github.com/user-attachments/assets/bd7d71b2-7479-487a-94a4-7c5b6f9a02b6" />



