### PR TITLE
small fixes, can have dp,dmg above tokens

### DIFF
--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -4,7 +4,8 @@
  * @return {Promise}
  */
 export const preloadHandlebarsTemplates = async function () {
-  return loadTemplates([
+  const load = foundry?.applications?.handlebars?.loadTemplates ?? globalThis.loadTemplates;
+  return load([
     // Actor partials.
     'systems/arkham-horror-rpg-fvtt/templates/actor/parts/actor-features.hbs',
     'systems/arkham-horror-rpg-fvtt/templates/actor/parts/actor-items.hbs',

--- a/module/util/configuration.mjs
+++ b/module/util/configuration.mjs
@@ -1,7 +1,7 @@
 export function setupConfiguration() {
     game.settings.register("arkham-horror-rpg-fvtt", "tokenShowDicePools", {
         name: "Show Token Dice Pools",
-        hint: "Show Dice Pool below tokens on the canvas.",
+        hint: "Show Dice Pool on tokens on the canvas.",
         scope: "world",
         config: true,
         type: Boolean,
@@ -10,11 +10,20 @@ export function setupConfiguration() {
 
     game.settings.register("arkham-horror-rpg-fvtt", "tokenShowDamage", {
         name: "Show Token Damage",
-        hint: "Show Damage below tokens on the canvas.",
+        hint: "Show Damage on tokens on the canvas.",
         scope: "world",
         config: true,
         type: Boolean,
         default: true
+    });
+
+    game.settings.register("arkham-horror-rpg-fvtt", "tokenOverlayAbove", {
+        name: "Token Overlay Above Token",
+        hint: "If enabled, show Dice Pool/Damage above the token instead of below.",
+        scope: "world",
+        config: true,
+        type: Boolean,
+        default: false
     });
 
     game.settings.register("arkham-horror-rpg-fvtt", "characterLoadCapacity", {


### PR DESCRIPTION
Fixing a couple of depreciation warnings this one has been around awhile
<img width="975" height="255" alt="image" src="https://github.com/user-attachments/assets/1c930cfe-180b-4a77-94eb-2ab9403657a6" />

These seem newer:
<img width="975" height="572" alt="image" src="https://github.com/user-attachments/assets/c1ed3f09-3e79-49a7-b588-f52ebc6f0331" />

Also, wanted to be able to not have character names covered by the custom DP/DMG on the tokens because I really like it but when having names on the tokens it conflicts on the overlay, so just made a simple setting to allow for it to be on top of the token instead of underneath.
<img width="800" height="573" alt="image" src="https://github.com/user-attachments/assets/06bdf195-4fa0-4e7c-b9e3-31a773322e19" />

<img width="975" height="384" alt="image" src="https://github.com/user-attachments/assets/44f2f009-26cb-419b-849f-f61e99b6cf6f" />


