### PR TITLE
Reaction Rolls v1

### DIFF
--- a/css/arkham-horror-rpg-fvtt.css
+++ b/css/arkham-horror-rpg-fvtt.css
@@ -429,7 +429,7 @@ form > nav > a.item.active {
 .arkham-roll-kind {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
+  padding: 4px 14px;
   border: 2px solid #722A1C;
   border-radius: 6px;
   background: rgba(114, 42, 28, 0.07);
@@ -682,6 +682,10 @@ form > nav > a.item.active {
   margin-top: 2px;
   font-family: "Voltaire", sans-serif;
   font-variant-numeric: tabular-nums;
+}
+
+.arkham-roll-reaction-icon {
+  margin-right: 6px;
 }
 
 li.chat-message.message {
@@ -1027,6 +1031,19 @@ li.chat-message.message > .message-content {
   font-size: 1.4em;
   text-shadow: 1px 1px rgba(210, 90, 63, 0.25);
 }
+.system-arkham-horror-rpg-fvtt .skills-list .skill-row {
+  grid-template-columns: 1fr 1fr 40px 40px 18px;
+  gap: 6px;
+  align-items: center;
+}
+.system-arkham-horror-rpg-fvtt .skills-list .skill-row .skill-reaction-icon {
+  margin-left: 0;
+  justify-self: center;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
 .system-arkham-horror-rpg-fvtt .npc-skill {
   font-family: "Teutonic", sans-serif;
   font-size: 1.4em;
@@ -1034,6 +1051,32 @@ li.chat-message.message > .message-content {
   text-align: center;
   width: 100%;
   display: block;
+}
+.system-arkham-horror-rpg-fvtt {
+  /* NPC skills: lock each skill tile to a 3-column grid so it won't wrap/jumble */
+}
+.system-arkham-horror-rpg-fvtt .npc-skill-entry {
+  display: grid;
+  grid-template-columns: 1fr 40px 18px;
+  align-items: center;
+  column-gap: 6px;
+}
+.system-arkham-horror-rpg-fvtt {
+  /* Override the global NPC label width just within the skill entry */
+}
+.system-arkham-horror-rpg-fvtt .npc-skill-entry .npc-skill {
+  width: auto;
+  min-width: 0;
+}
+.system-arkham-horror-rpg-fvtt .npc-skill-entry input {
+  width: 40px;
+  justify-self: center;
+}
+.system-arkham-horror-rpg-fvtt .npc-skill-entry .skill-reaction-icon {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .system-arkham-horror-rpg-fvtt .small-input {
   width: 33px;
@@ -1244,5 +1287,3 @@ li.chat-message.message > .message-content {
 .editor.prosemirror {
   height: 100%;
 }
-
-/*# sourceMappingURL=arkham-horror-rpg-fvtt.css.map */

--- a/module/rolls/skill-roll-workflow.mjs
+++ b/module/rolls/skill-roll-workflow.mjs
@@ -8,6 +8,8 @@ import {
 } from "../helpers/roll-engine.mjs";
 import { createArkhamHorrorChatCard } from "../util/chat-utils.mjs";
 
+const SYSTEM_ID = "arkham-horror-rpg-fvtt";
+
 
 export class SkillRollWorkflow {
   async plan({ actor, state }) {
@@ -122,7 +124,13 @@ export class SkillRollWorkflow {
   buildChat({ state, outcome }) {
     const template = "systems/arkham-horror-rpg-fvtt/templates/chat/roll-result.hbs";
 
+    const rollKind = String(state?.rollKind ?? "complex");
+    const rollKindLabel = rollKind === "reaction" ? "Reaction" : "Complex";
+
     const chatData = {
+      rollCategory: "skill",
+      rollKind,
+      rollKindLabel,
       diceRollHTML: outcome.diceRollHTML,
       horrorDiceRollHTML: outcome.horrorDiceRollHTML,
       successOn: outcome.successOn,
@@ -155,8 +163,14 @@ export class SkillRollWorkflow {
 
   async post({ actor, state, outcome }) {
     const { template, chatData } = this.buildChat({ state, outcome });
+    //destructure chatData to separate diceRollHTML and horrorDiceRollHTML from the rest of the flags 
+    // so we aren't passing rendered content strings to every roll
+    const { diceRollHTML, horrorDiceRollHTML, ...flagsData } = chatData;
+    const flags = {
+      [SYSTEM_ID]: flagsData
+    };
     // render and post chat message new method
-    return createArkhamHorrorChatCard( {actor, template, chatVars: chatData, flags: {"arkham-horror-rpg-fvtt": chatData}});
+    return createArkhamHorrorChatCard({ actor, template, chatVars: chatData, flags });
     }
 
   /**

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -24,6 +24,7 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
             toggleFoldableContent: this.#handleToggleFoldableContent,
             openActorArchetype: this.#handleOpenActorArchetype,
             clickSkill: this.#handleSkillClicked,
+            clickSkillReaction: this.#handleSkillReactionClicked,
             clickWeaponReload: this.#handleWeaponReload,
             clickedRefreshDicePool: this.#handleClickedRefreshDicePool,
             clickedRollWithWeapon: this.#handleClickedRollWithWeapon,
@@ -500,6 +501,17 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
         let skillMax = this.actor.system.skills[skillKey].max;
         let currentDicePool = this.actor.system.dicepool.value;
          DiceRollApp.getInstance({ actor: this.actor, skillKey: skillKey, skillCurrent: skillCurrent, skillMax: skillMax, currentDicePool: currentDicePool,weaponToUse: null }).render(true);
+    }
+
+    static async #handleSkillReactionClicked(event, target) {
+        event.preventDefault();
+        const skillKey = target.dataset.skillKey;
+
+        let skillCurrent = this.actor.system.skills[skillKey].current;
+        let skillMax = this.actor.system.skills[skillKey].max;
+        let currentDicePool = this.actor.system.dicepool.value;
+
+        DiceRollApp.getInstance({ actor: this.actor, rollKind: "reaction", skillKey: skillKey, skillCurrent: skillCurrent, skillMax: skillMax, currentDicePool: currentDicePool, weaponToUse: null }).render(true);
     }
 
     static async #handleWeaponReload(event, target) {

--- a/module/sheets/npc-sheet.mjs
+++ b/module/sheets/npc-sheet.mjs
@@ -24,6 +24,7 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
             deleteItem: this.#handleDeleteItem,
             toggleFoldableContent: this.#handleToggleFoldableContent,
             clickSkill: this.#handleSkillClicked,
+            clickSkillReaction: this.#handleSkillReactionClicked,
             clickWeaponReload: this.#handleWeaponReload,
             clickedRefreshDicePool: this.#handleClickedRefreshDicePool,
             clickedRollWithWeapon: this.#handleClickedRollWithWeapon,
@@ -278,6 +279,17 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         let currentDicePool = this.actor.system.dicepool.value;
 
         DiceRollApp.getInstance({ actor: this.actor, skillKey: skillKey, skillCurrent: skillCurrent, skillMax: skillMax, currentDicePool: currentDicePool, weaponToUse: null }).render(true);
+    }
+
+    static async #handleSkillReactionClicked(event, target) {
+        event.preventDefault();
+        const skillKey = target.dataset.skillKey;
+
+        let skillCurrent = this.actor.system.skills[skillKey].current;
+        let skillMax = this.actor.system.skills[skillKey].max;
+        let currentDicePool = this.actor.system.dicepool.value;
+
+        DiceRollApp.getInstance({ actor: this.actor, rollKind: "reaction", skillKey: skillKey, skillCurrent: skillCurrent, skillMax: skillMax, currentDicePool: currentDicePool, weaponToUse: null }).render(true);
     }
 
     static async #handleWeaponReload(event, target) {

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -226,10 +226,28 @@
     }
   }
 }
+
 .skill {
   font-family: $font-primary;
   font-size: 1.4em;
   text-shadow: 1px 1px rgba(210, 90, 63, 0.25);
+}
+
+// Character sheet skills: keep the reaction icon in its own fixed-width column
+// instead of consuming a full 1fr grid track.
+.skills-list .skill-row {
+  grid-template-columns: 1fr 1fr 40px 40px 18px;
+  gap: 6px;
+  align-items: center;
+}
+
+.skills-list .skill-row .skill-reaction-icon {
+  margin-left: 0;
+  justify-self: center;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .npc-skill {
@@ -239,6 +257,32 @@
   text-align: center;
   width: 100%;
   display: block;
+}
+
+/* NPC skills: lock each skill tile to a 3-column grid so it won't wrap/jumble */
+.npc-skill-entry {
+  display: grid;
+  grid-template-columns: 1fr 40px 18px;
+  align-items: center;
+  column-gap: 6px;
+}
+
+/* Override the global NPC label width just within the skill entry */
+.npc-skill-entry .npc-skill {
+  width: auto;
+  min-width: 0;
+}
+
+.npc-skill-entry input {
+  width: 40px;
+  justify-self: center;
+}
+
+.npc-skill-entry .skill-reaction-icon {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .small-input {

--- a/src/scss/global/_chat.scss
+++ b/src/scss/global/_chat.scss
@@ -27,7 +27,7 @@
 .arkham-roll-kind {
     display: inline-flex;
     align-items: center;
-    padding: 4px 10px;
+    padding: 4px 14px;
     border: 2px solid $c-red;
     border-radius: 6px;
     background: rgba($c-red, 0.07);
@@ -286,6 +286,10 @@
     margin-top: 2px;
     font-family: "Voltaire", sans-serif;
     font-variant-numeric: tabular-nums;
+}
+
+.arkham-roll-reaction-icon {
+  margin-right: 6px;
 }
 
 // -----------------------------------------------------------------------------

--- a/templates/actor/parts/_skill.hbs
+++ b/templates/actor/parts/_skill.hbs
@@ -1,5 +1,8 @@
-<div class="grid grid-4col">
+<div class="grid grid-5col skill-row">
     <label class="grid-span-2 skill clickable" data-action="clickSkill" data-skill-key="{{skillKey}}">{{localize (concat "ARKHAM_HORROR.SKILL." skillKey)}}</label>
     <input type="number" name="system.skills.{{skillKey}}.current" value="{{skillData.current}}" data-dtype="Number" title="Limit" class="fancy-input">
     <input type="number" name="system.skills.{{skillKey}}.max" value="{{skillData.max}}" data-dtype="Number" title="Max" class="fancy-input">
+    <span class="skill-reaction-icon clickable" data-action="clickSkillReaction" data-skill-key="{{skillKey}}" title="Reaction roll">
+        <i class="fa-solid fa-arrow-rotate-left"></i>
+    </span>
 </div>

--- a/templates/chat/roll-result.hbs
+++ b/templates/chat/roll-result.hbs
@@ -1,7 +1,12 @@
 <section class="arkham-roll-card">
     <header class="arkham-roll-header">
         <div class="arkham-roll-heading">
-            <span class="arkham-roll-kind">{{skillUsed}}</span>
+            <span class="arkham-roll-kind">
+                {{#if (eq rollKind "reaction")}}
+                    <i class="fa-solid fa-arrow-rotate-left arkham-roll-reaction-icon" title="Reaction roll"></i>
+                {{/if}}
+                {{skillUsed}}
+            </span>
         </div>
         <div class="arkham-roll-subtitle">Success on <span class="arkham-emph">{{successOn}}+</span></div>
     </header>

--- a/templates/dice-roll-app/dialog.hbs
+++ b/templates/dice-roll-app/dialog.hbs
@@ -2,11 +2,15 @@
     <div class="form-group">
         <label for="dicepool">Dice Pool</label>
         <div class="flexrow">
-            <button class="button-dicepool-rolldialog" data-action="clickedDecreaseDicePool">-</button>
-            <input type="number" id="dicepool" name="diceToUse" value="{{diceToUse}}" min="0"> / 
+            <button class="button-dicepool-rolldialog" data-action="clickedDecreaseDicePool" {{#if isReaction}}disabled{{/if}}>-</button>
+            <input type="number" id="dicepool" name="diceToUse" value="{{diceToUse}}" min="0" {{#if isReaction}}readonly{{/if}}> / 
             <input type="number" name="currentDicePool" value="{{currentDicePool}}" min="0" readonly>
-            <button class="button-dicepool-rolldialog" data-action="clickedIncreaseDicePool">+</button>
+            <button class="button-dicepool-rolldialog" data-action="clickedIncreaseDicePool" {{#if isReaction}}disabled{{/if}}>+</button>
         </div>
+    </div>
+    <div class="form-group">
+        <label for="roll-kind">Roll Type</label>
+        <input type="text" id="roll-kind" name="rollKindLabel" value="{{rollKindLabel}}" readonly>
     </div>
     <div class="form-group">
         <label for="skill-key">Skill</label>

--- a/templates/npc/parts/_skill.hbs
+++ b/templates/npc/parts/_skill.hbs
@@ -1,4 +1,7 @@
 <div class="npc-skill-entry flexrow">
     <label class="npc-skill clickable" data-action="clickSkill" data-skill-key="{{skillKey}}">{{label}}</label>
     <input type="number" name="system.skills.{{skillKey}}.current" value="{{skillData.current}}" data-dtype="Number" title="Limit">
+    <div class="skill-reaction-icon clickable" data-action="clickSkillReaction" data-skill-key="{{skillKey}}" title="Reaction roll">
+        <i class="fa-solid fa-arrow-rotate-left"></i>
+    </div>
 </div>


### PR DESCRIPTION
This PR contains the first iteration of the ability for users to have a quick access button to reaction rolls, learning to use this rather than a normal complex roll set at 1 also allows for future branching and automation off of "reaction" type rolls for knacks etc.

While branch name calls out reroll that is not included in this PR.  MrTheBino 🥇 did great work on making things look very good and orderly on the skills areas, and I hope that I didn't ruin it by adding the fa icons for rerolls, we can come back on a v2 pass if needed.

<img width="975" height="933" alt="image" src="https://github.com/user-attachments/assets/2e20ebd3-37e0-4796-a515-3cab0089e18f" />

<img width="975" height="726" alt="image" src="https://github.com/user-attachments/assets/97d84085-4ed3-46eb-be0d-2522e6be70d2" />

<img width="975" height="589" alt="image" src="https://github.com/user-attachments/assets/d1cb804a-d6d1-40c4-b92a-32415ce9af14" />

<img width="400" height="1350" alt="image" src="https://github.com/user-attachments/assets/7e0a8429-8fd4-451a-acc5-7561b6338ea6" />
