### PR TITLE
D3 rolls v1

### DIFF
--- a/module/arkham-horror-rpg-fvtt.mjs
+++ b/module/arkham-horror-rpg-fvtt.mjs
@@ -23,6 +23,8 @@ import * as models from './data/_module.mjs';
 import { setupConfiguration } from './util/configuration.mjs';
 import { registerChatRerollHooks } from './hooks/chat-reroll-hooks.mjs';
 
+import { refreshDicepoolAndPost } from './helpers/dicepool.mjs';
+
 
 /* -------------------------------------------- */
 /*  Init Hook                                   */
@@ -210,25 +212,7 @@ async function arkhamHorrorResetSceneActorDicePool() {
   for (let token of canvas.tokens.placeables) {
     const actor = token.actor;
     if (actor?.type === 'character' || actor?.type === 'npc') {
-      let oldValue = actor.system.dicepool.value;
-      let newValue = actor.system.dicepool.max - actor.system.damage;
-      await actor.update({ 'system.dicepool.value': newValue });
-
-      const chatVars = {
-        label: 'Dicepool Reset',
-        actorName: actor.name,
-        oldDicePoolValue: oldValue,
-        newDicePoolValue: newValue
-      };
-
-      const html = await foundry.applications.handlebars.renderTemplate(
-        "systems/arkham-horror-rpg-fvtt/templates/chat/dicepool-reset.hbs",
-        chatVars
-      );
-      ChatMessage.create({
-        content: html,
-        speaker: ChatMessage.getSpeaker({ actor }),
-      });
+      await refreshDicepoolAndPost({ actor, label: "Dicepool Reset", healDamage: false });
     }
   }
 }

--- a/module/helpers/dicepool.mjs
+++ b/module/helpers/dicepool.mjs
@@ -1,0 +1,49 @@
+import { createArkhamHorrorChatCard } from "../util/chat-utils.mjs";
+
+const SYSTEM_ID = "arkham-horror-rpg-fvtt";
+const TEMPLATE = `systems/${SYSTEM_ID}/templates/chat/dicepool-reset.hbs`;
+
+export async function refreshDicepoolAndPost({ actor, label = "Dicepool Refresh", healDamage = false } = {}) {
+  if (!actor) throw new Error("refreshDicepoolAndPost requires an actor");
+
+  const oldDamage = Number(actor.system?.damage ?? 0);
+  const oldDicePoolValue = Number(actor.system?.dicepool?.value ?? 0);
+  const dicePoolMax = Number(actor.system?.dicepool?.max ?? 0);
+
+  const newDamage = healDamage ? 0 : oldDamage;
+  const newDicePoolValue = Math.max(0, dicePoolMax - newDamage);
+
+  const updateData = {
+    "system.dicepool.value": newDicePoolValue,
+  };
+  if (healDamage && oldDamage !== 0) updateData["system.damage"] = 0;
+
+  await actor.update(updateData);
+
+  const healedDamage = Math.max(0, oldDamage - newDamage);
+
+  const chatVars = {
+    label,
+    actorName: actor.name,
+    oldDicePoolValue,
+    newDicePoolValue,
+    healedDamage,
+  };
+
+  const flags = {
+    [SYSTEM_ID]: {
+      ...chatVars,
+      rollCategory: "dicepool",
+    },
+  };
+
+  await createArkhamHorrorChatCard({ actor, template: TEMPLATE, chatVars, flags });
+
+  return {
+    oldDamage,
+    newDamage,
+    healedDamage,
+    oldDicePoolValue,
+    newDicePoolValue,
+  };
+}

--- a/module/helpers/roll-engine.mjs
+++ b/module/helpers/roll-engine.mjs
@@ -9,15 +9,18 @@ export function addShowDicePromise(promises, roll) {
   }
 }
 
-// Core D6 rolling function
-// if rolling separately for horror dice, pass in dicePromises to collect all show dice promises together, see implementation in execute() in skill-roll-workflow.mjs
-export async function rollD6({ actor, numDice, dicePromises } = {}) {
-  const roll = new Roll(`${numDice}d6`, actor.getRollData());
+// Core dice rolling function
+// If rolling separately for horror dice, pass in dicePromises to collect all show dice promises together.
+export async function rollDice({ actor, numDice, faces = 6, dicePromises } = {}) {
+  const n = Number.parseInt(numDice) || 0;
+  const f = Number.parseInt(faces) || 6;
+
+  const roll = new Roll(`${n}d${f}`, actor.getRollData());
   await roll.evaluate();
 
   // Render immediately (old app rendered before awaiting DSN)
   const html = await roll.render();
-  const results = roll.terms[0].results.map(r => r.result);
+  const results = roll.terms?.[0]?.results?.map(r => r.result) ?? [];
 
   if (dicePromises) {
     addShowDicePromise(dicePromises, roll);
@@ -28,6 +31,16 @@ export async function rollD6({ actor, numDice, dicePromises } = {}) {
   }
 
   return { roll, html, results };
+}
+
+// Backwards-compatible D6 wrapper
+export async function rollD6({ actor, numDice, dicePromises } = {}) {
+  return rollDice({ actor, numDice, faces: 6, dicePromises });
+}
+
+// Convenience D3 wrapper
+export async function rollD3({ actor, numDice, dicePromises } = {}) {
+  return rollDice({ actor, numDice, faces: 3, dicePromises });
 }
 
 // Computes dice pools + success threshold exactly like original logic from 13.0.7 ALPHA dice-roll-app.

--- a/module/rolls/injury-trauma-workflow.mjs
+++ b/module/rolls/injury-trauma-workflow.mjs
@@ -182,8 +182,24 @@ export class InjuryTraumaWorkflow {
     const dieFaces = rollMode === "falling" ? 3 : (requestedFaces === 3 ? 3 : 6);
 
     const fallingHeightFt = Number.parseInt(state?.fallingHeightFt) || 0;
+
+    // Validate at the source of truth (workflow), not only in the UI.
+    // This protects against macros/future automation calling the workflow directly.
+    if (rollMode === "falling") {
+      if (rollKind !== "injury") {
+        const msg = "Falling mode only applies to Injury rolls.";
+        warnOnce(`${SYSTEM_ID}|invalidFallingKind`, `[${SYSTEM_ID}] ${msg}`);
+        throw new Error(msg);
+      }
+      if (fallingHeightFt < 10) {
+        const msg = "Falling height must be at least 10 ft.";
+        warnOnce(`${SYSTEM_ID}|invalidFallingHeight`, `[${SYSTEM_ID}] ${msg}`);
+        throw new Error(msg);
+      }
+    }
+
     const numDice = rollMode === "falling"
-      ? Math.max(1, Math.floor(fallingHeightFt / 10))
+      ? Math.floor(fallingHeightFt / 10)
       : 1;
 
     const modifierApplied = rollMode !== "falling";

--- a/module/sheets/npc-sheet.mjs
+++ b/module/sheets/npc-sheet.mjs
@@ -4,6 +4,7 @@ const { TextEditor, DragDrop } = foundry.applications.ux
 import { ArkhamHorrorItem } from "../documents/item.mjs";
 import { DiceRollApp } from '../apps/dice-roll-app.mjs';
 import { InjuryTraumaRollApp } from '../apps/injury-trauma-roll-app.mjs';
+import { refreshDicepoolAndPost } from "../helpers/dicepool.mjs";
 
 export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     #dragDrop // Private field to hold dragDrop handlers
@@ -19,6 +20,7 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         actions: {
             clickedDicePool: this.#handleClickedDicePool,
             clickedClearDicePool: this.#handleClickedClearDicePool,
+            clickedStrainOneself: this.#handleClickedStrainOneself,
             editItem: this.#handleEditItem,
             createItem: this.#handleCreateItem,
             deleteItem: this.#handleDeleteItem,
@@ -326,9 +328,31 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
     }
 
     static async #handleClickedRefreshDicePool(event, target) {
-        let oldValue = this.actor.system.dicepool.value;
-        let newValue = this.actor.system.dicepool.max - this.actor.system.damage;
-        await this.actor.update({ 'system.dicepool.value': newValue });
+        await refreshDicepoolAndPost({ actor: this.actor, label: "Dicepool Refresh", healDamage: false });
+    }
+
+    static async #handleClickedStrainOneself(event, target) {
+        event.preventDefault();
+
+        if (!this.actor?.isOwner) {
+            ui.notifications.warn('You do not have permission to strain for this Actor.');
+            return;
+        }
+
+        const currentDamage = Number(this.actor.system?.damage ?? 0);
+        if (currentDamage <= 0) {
+            ui.notifications.warn('You can only strain when your dice pool maximum is reduced by damage.');
+            return;
+        }
+
+        await refreshDicepoolAndPost({ actor: this.actor, label: "Strain Oneself", healDamage: true });
+
+        InjuryTraumaRollApp.getInstance({
+            actor: this.actor,
+            rollKind: "injury",
+            modifier: 0,
+            rollSource: "strain",
+        }).render(true);
     }
 
     static async #handleClickedRollWithWeapon(event, target) {

--- a/templates/actor/parts/character-dicepool.hbs
+++ b/templates/actor/parts/character-dicepool.hbs
@@ -11,5 +11,6 @@
                 alt="Regular Die" /></span>
         {{/if}}
     {{/each}}
+    <span class="dice-action-icon" data-action="clickedStrainOneself" title="Strain Oneself"><i class="fa-solid fa-hand-fist"></i></span>
     <span class="dice-action-icon" data-action="clickedRefreshDicePool" title="Refresh" ><i class="fa-solid fa-arrow-rotate-right"></i></span>
 </div>

--- a/templates/chat/dicepool-reset.hbs
+++ b/templates/chat/dicepool-reset.hbs
@@ -1,3 +1,6 @@
 <div>
-    {{actorName}}'s dice pool has been reset from {{oldDicePoolValue}} to {{newDicePoolValue}}.
+    <strong>{{label}}</strong>: {{actorName}}'s dice pool changed from {{oldDicePoolValue}} to {{newDicePoolValue}}.
+    {{#if healedDamage}}
+        (Healed {{healedDamage}} damage)
+    {{/if}}
 </div>

--- a/templates/chat/injury-trauma-roll-card.hbs
+++ b/templates/chat/injury-trauma-roll-card.hbs
@@ -1,7 +1,23 @@
 <section class="arkham-roll-card arkham-injury-trauma-card" data-roll-category="injury-trauma" data-roll-kind="{{rollKind}}">
   <header class="arkham-roll-header">
     <div class="arkham-roll-heading">
-      <span class="arkham-roll-kind {{#if (eq rollKind "injury")}}is-injury{{else}}is-trauma{{/if}}">{{rollKindLabel}}</span>
+      <span class="arkham-roll-kind {{#if (eq rollKind "injury")}}is-injury{{else}}is-trauma{{/if}}">
+        {{#if (eq rollMode "falling")}}
+          <i class="fa-solid fa-person-falling arkham-roll-reaction-icon" title="Falling" aria-hidden="true"></i>
+        {{else if (eq rollSource "strain")}}
+          <i class="fa-solid fa-hand-fist arkham-roll-reaction-icon" title="Strain Oneself" aria-hidden="true"></i>
+        {{/if}}
+        {{rollKindLabel}}
+      </span>
+    </div>
+
+    <div class="arkham-roll-subtitle">
+      <span class="arkham-roll-flag is-diff">
+        {{numDice}}d{{dieFaces}}
+        {{#if modifierApplied}}
+          {{#if (gte modifier 0)}}+{{modifier}}{{else}}{{modifier}}{{/if}}
+        {{/if}}
+      </span>
     </div>
   </header>
 
@@ -9,30 +25,62 @@
     {{tableResultName}}
   </div>
 
+  {{#if (eq rollSource "strain")}}
+    <div class="arkham-injury-trauma-description">
+      <strong>Strain Oneself:</strong> apply the resulting injury at end of turn / after 1 complex action.
+    </div>
+  {{/if}}
+
+  {{#if (eq rollMode "falling")}}
+    <div class="arkham-injury-trauma-description">
+      <strong>Falling Injury</strong> — Height: {{fallingHeightFt}} ft
+    </div>
+  {{/if}}
+
   {{#if tableResultDescription}}
     <div class="arkham-injury-trauma-description">
       {{{tableResultDescription}}}
     </div>
   {{/if}}
 
-  <div class="arkham-roll-results">
-    <div class="arkham-roll-meta">
-      <div class="arkham-meta-row">
-        <span class="arkham-meta-label">Die</span>
-        <span class="arkham-meta-value">{{dieResult}}</span>
-      </div>
-      <div class="arkham-meta-row">
-        <span class="arkham-meta-label">Modifier</span>
-        <span class="arkham-meta-value">{{modifier}}</span>
-      </div>
-      <div class="arkham-meta-row">
-        <span class="arkham-meta-label">Total</span>
-        <span class="arkham-meta-value">{{total}}</span>
-      </div>
-      <div class="arkham-meta-row">
-        <span class="arkham-meta-label">Table</span>
-        <span class="arkham-meta-value">{{tableRange}}</span>
+  <details class="arkham-roll-details">
+    <summary class="arkham-roll-details-summary">Roll Details</summary>
+    <div class="arkham-roll-details-body">
+      <div class="arkham-roll-meta">
+        <div class="arkham-meta-row">
+          <span class="arkham-meta-label">Roll</span>
+          <span class="arkham-meta-value">{{numDice}}d{{dieFaces}}</span>
+        </div>
+
+        {{#if (eq numDice 1)}}
+          <div class="arkham-meta-row">
+            <span class="arkham-meta-label">Die</span>
+            <span class="arkham-meta-value">{{dieResult}}</span>
+          </div>
+        {{else}}
+          <div class="arkham-meta-row">
+            <span class="arkham-meta-label">Dice</span>
+            <span class="arkham-meta-value">{{dieResultsLabel}}</span>
+          </div>
+          <div class="arkham-meta-row">
+            <span class="arkham-meta-label">Die Total</span>
+            <span class="arkham-meta-value">{{dieTotal}}</span>
+          </div>
+        {{/if}}
+
+        <div class="arkham-meta-row">
+          <span class="arkham-meta-label">Modifier</span>
+          <span class="arkham-meta-value">{{#if modifierApplied}}{{modifier}}{{else}}—{{/if}}</span>
+        </div>
+        <div class="arkham-meta-row">
+          <span class="arkham-meta-label">Total</span>
+          <span class="arkham-meta-value">{{total}}</span>
+        </div>
+        <div class="arkham-meta-row">
+          <span class="arkham-meta-label">Table</span>
+          <span class="arkham-meta-value">{{tableRange}}</span>
+        </div>
       </div>
     </div>
-  </div>
+  </details>
 </section>

--- a/templates/injury-trauma-roll-app/dialog.hbs
+++ b/templates/injury-trauma-roll-app/dialog.hbs
@@ -8,11 +8,34 @@
   </div>
 
   <div class="form-group">
+    <label>Mode</label>
+    <select name="rollMode">
+      <option value="standard" {{#if (eq rollMode "standard")}}selected{{/if}}>Standard</option>
+      <option value="falling" {{#if (eq rollMode "falling")}}selected{{/if}}>Falling</option>
+    </select>
+  </div>
+
+  <div class="form-group" data-roll-mode="standard">
+    <label>Die</label>
+    <select name="dieFaces">
+      <option value="6" {{#if (eq dieFaces 6)}}selected{{/if}}>d6</option>
+      <option value="3" {{#if (eq dieFaces 3)}}selected{{/if}}>d3</option>
+    </select>
+  </div>
+
+  <div class="form-group" data-roll-mode="falling">
+    <label>Falling Height (ft)</label>
+    <input type="number" name="fallingHeightFt" value="{{fallingHeightFt}}" min="10" step="1" />
+  </div>
+
+  <div class="form-group">
     <label>Modifier</label>
     <input type="number" name="modifier" value="{{modifier}}" step="1" />
   </div>
 
-  <p class="arkham-horror-hint">Total = 1d6 + modifier</p>
+  <input type="hidden" name="rollSource" value="{{rollSource}}" />
+
+  <p class="arkham-horror-hint" data-role="formulaHint">{{formulaHint}}</p>
 
   <footer class="dialog-footer">
     <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> Roll</button>


### PR DESCRIPTION
The system needs to be able to handle things like the Brawler Knack where a player rolls 1d3 on the injury table rather than 1d6, also this allows for a "falling" injury roll where there are multiple d3's rolled on the injury table to determine injury.  d3 can also be rolled on the Trauma table if needed.

This v1 does not support an additional button for rolling a raw d3 for cases where "an investigator takes 1d3 horror" as this can as easily be handled in the standard chat dialog of "/r 1d3" but we have completed the core roll engine refactor to allow a quick button from the actor sheet in the future if we want that functionality.

Also added the ability to "Strain Oneself" following the rules outlined in the book as a quick button that immediately pops the injury dialog.

- Adds d3 support to the Injury/Trauma workflow, including a manual die selector (d6 vs d3) and a dedicated Falling mode (injury only) that rolls floor(height/10)d3 (height must be ≥ 10 ft, no modifier applied).
- Adds a new “Strain Oneself” actor sheet action that heals current damage, restores the dice pool to max, posts a chat notice, and then opens the Injury/Trauma dialog with the resulting chat card tagged as “From Strain Oneself”

Changes

- Dice engine generalized from rollD6 to a reusable rollDice({ faces }) with rollD6/rollD3 wrappers in roll-engine.mjs
- New shared dicepool helper to keep Actor + NPC behavior consistent and reduce duplication: helpers/dicepool.mjs
- Injury/Trauma dialog UI extended with roll mode + die selection + falling height inputs
- Workflow updated to support multi-die falling rolls and to pass roll metadata into chat rendering
- Chat cards updated for clarity:
    - Dicepool refresh/strain messaging in dicepool-reset.hbs
    - Injury/Trauma roll card now displays strain/falling context and clearer roll breakdown in injury-trauma-roll-card.hbs
- “Strain Oneself” fist icon button added near the dicepool refresh control for both Character and NPC

<img width="732" height="607" alt="image" src="https://github.com/user-attachments/assets/964f2d9e-00d1-477c-95b0-285763fb96c3" />

<img width="300" height="377" alt="image" src="https://github.com/user-attachments/assets/6fca4d61-755d-4a29-b7b2-eb2856317917" />

<img width="694" height="581" alt="image" src="https://github.com/user-attachments/assets/62cfd904-52e9-40e1-b303-499098455d27" />

<img width="281" height="334" alt="image" src="https://github.com/user-attachments/assets/b3d33e10-f499-4028-8579-075551786e6d" />
