### PR TITLE
Knacks Initial automation + additional build

### DIFF
--- a/css/arkham-horror-rpg-fvtt.css
+++ b/css/arkham-horror-rpg-fvtt.css
@@ -1231,6 +1231,111 @@ li.chat-message.message > .message-content {
 .system-arkham-horror-rpg-fvtt .foldable-content.collapsed {
   display: block;
 }
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .dialog-footer--primary {
+  margin-top: 10px;
+  margin-bottom: 6px;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices {
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices > label {
+  flex: 0 0 100%;
+  min-width: 0;
+  margin-bottom: 2px;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices > .notes {
+  flex: 0 0 100%;
+  margin: 0 0 6px 0;
+  font-size: 0.9em;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row {
+  flex: 0 0 100%;
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  column-gap: 8px;
+  align-items: start;
+  padding: 1px 0;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row + .knack-choice-row {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row input[type=checkbox] {
+  margin: 2px 0 0 0;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row span {
+  min-width: 0;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row small.notes {
+  display: block;
+  margin: 2px 0 0 0;
+  font-size: 0.85em;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row.is-checked {
+  background: rgba(114, 42, 28, 0.1);
+  border-left: 3px solid rgba(114, 42, 28, 0.6);
+  padding-left: 6px;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row.is-disabled {
+  opacity: 0.75;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row.is-disabled input[type=checkbox] {
+  cursor: not-allowed;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-choice-row.is-disabled .knack-availability {
+  color: rgba(114, 42, 28, 0.95);
+  font-weight: 600;
+  margin-left: 4px;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-refresh {
+  margin-left: 8px;
+  height: 24px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: 0.9em;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  background: rgba(255, 255, 255, 0.2);
+  font-family: "Teutonic", sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  align-self: start;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-refresh:hover {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(0, 0, 0, 0.75);
+  cursor: pointer;
+  align-self: start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-preview {
+  margin: 0 0 6px 0;
+  padding: 4px 6px;
+  background: rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  border-radius: 4px;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-preview__title {
+  margin-bottom: 2px;
+  color: rgb(114, 42, 28);
+  font-family: "Teutonic", sans-serif;
+  font-size: 0.95em;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-preview__text {
+  font-size: 0.95em;
+}
+.system-arkham-horror-rpg-fvtt .roll-dialog-container .form-group.knack-choices .knack-effect {
+  margin-left: 6px;
+  font-size: 0.9em;
+  opacity: 0.9;
+}
 .system-arkham-horror-rpg-fvtt .sheet.actor .resource-group,
 .system-arkham-horror-rpg-fvtt .sheet.item .resource-group {
   margin-top: 10px;
@@ -1249,6 +1354,67 @@ li.chat-message.message > .message-content {
 .system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled input,
 .system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled select {
   height: 20px;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet select.knack-multiselect,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet select.knack-multiselect {
+  height: auto;
+  min-height: 120px;
+  padding: 3px 6px;
+  font-size: 1.1em;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-picker,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-picker {
+  width: 100%;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-picker__controls,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-picker__controls {
+  display: grid;
+  grid-template-columns: 1fr 34px;
+  gap: 8px;
+  align-items: center;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-picker__select,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-picker__select {
+  width: 100%;
+  height: 28px;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-picker__add,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-picker__add {
+  width: 34px;
+  height: 28px;
+  line-height: 26px;
+  padding: 0;
+  font-weight: 700;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  background: rgba(255, 255, 255, 0.25);
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-picker__selected,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-picker__selected {
+  margin-top: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-pill,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
+  font-family: "Lusitana", serif;
+  font-size: 0.95em;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-pill__remove,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-pill__remove {
+  color: rgba(0, 0, 0, 0.75);
+  text-decoration: none;
+}
+.system-arkham-horror-rpg-fvtt .sheet.actor .resource-group-styled.knack-sheet .knack-pill__remove:hover,
+.system-arkham-horror-rpg-fvtt .sheet.item .resource-group-styled.knack-sheet .knack-pill__remove:hover {
+  color: rgb(114, 42, 28);
 }
 .system-arkham-horror-rpg-fvtt .sheet.actor nav.tabs [data-group=sheet],
 .system-arkham-horror-rpg-fvtt .sheet.item nav.tabs [data-group=sheet] {

--- a/module/data/item-knack.mjs
+++ b/module/data/item-knack.mjs
@@ -6,8 +6,81 @@ export default class ArkhamHorrorKnack extends ArkhamHorrorItemBase {
     const fields = foundry.data.fields;
     const schema = super.defineSchema();
     const requiredInteger = { required: true, nullable: false, integer: true };
+
+    const DocumentUUIDField = fields.DocumentUUIDField ?? fields.StringField;
     
     schema.tier = new fields.NumberField({ ...requiredInteger, initial: 0, min: 0 });
+
+    // Usage tracking is stored, but reset automation is intentionally manual in v1.
+    schema.usage = new fields.SchemaField({
+      frequency: new fields.StringField({
+        required: true,
+        nullable: false,
+        initial: "passive",
+        choices: ["passive", "oncePerTurn", "oncePerScene", "oncePerSession", "unlimited"],
+      }),
+
+      max: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
+      remaining: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
+    });
+
+    // Roll effects are prompt-selectable only in v1.
+    schema.rollEffects = new fields.SchemaField({
+      enabled: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+
+      // Skill keys (prefer using existing actor system keys to avoid mapping bugs).
+      skillKeys: new fields.ArrayField(
+        new fields.StringField({
+          required: true,
+          nullable: false,
+          choices: [
+            "any",
+            "agility",
+            "athletics",
+            "wits",
+            "presence",
+            "intuition",
+            "knowledge",
+            "resolve",
+            "meleeCombat",
+            "rangedCombat",
+            "lore",
+          ],
+        }),
+        { initial: ["any"] }
+      ),
+
+      // Roll kinds as used by DiceRollApp.rollState.rollKind.
+      rollKinds: new fields.ArrayField(
+        new fields.StringField({
+          required: true,
+          nullable: false,
+          choices: ["any", "complex", "reaction", "tome-understand", "tome-attune"],
+        }),
+        { initial: ["any"] }
+      ),
+
+      modifier: new fields.SchemaField({
+        addBonusDice: new fields.NumberField({ ...requiredInteger, initial: 0, min: 0 }),
+        resultModifier: new fields.NumberField({ ...requiredInteger, initial: 0 }),
+        advantage: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+        disadvantage: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+
+        // For reroll-style knacks, this is an allowance recorded on the roll result.
+        // Enforcement is intentionally deferred.
+        rerollAllowanceDice: new fields.NumberField({ ...requiredInteger, initial: 0, min: 0 }),
+      }),
+    });
+
+    // Grants: primarily spell UUID references. These are applied immediately when the knack is acquired.
+    // We store structured grant entries to allow future expansion beyond spells.
+    schema.grants = new fields.ArrayField(
+      new fields.SchemaField({
+        type: new fields.StringField({ required: true, nullable: false, initial: "spell", choices: ["spell"] }),
+        uuid: new DocumentUUIDField({ required: true, nullable: false, blank: false }),
+      }),
+      { initial: [] }
+    );
 
     return schema;
   }

--- a/module/helpers/knacks.mjs
+++ b/module/helpers/knacks.mjs
@@ -1,0 +1,299 @@
+const SYSTEM_ID = "arkham-horror-rpg-fvtt";
+
+function isActorEmbeddedItem(item) {
+  return !!item?.parent && item.parent instanceof Actor;
+}
+
+function normalizeGrants(knack) {
+  const grants = Array.isArray(knack?.system?.grants) ? knack.system.grants : [];
+  return grants
+    .map(g => ({ type: String(g?.type ?? ""), uuid: String(g?.uuid ?? "") }))
+    .filter(g => g.type === "spell" && !!g.uuid);
+}
+
+function getManagedSpellForGrant({ actor, grantUuid }) {
+  const spells = actor.items?.contents ?? [];
+  return spells.find(i => {
+    if (i.type !== "spell") return false;
+    const flags = i.flags?.[SYSTEM_ID] ?? {};
+    if (flags?.grantKind !== "knack") return false;
+    return String(flags?.grantSourceUuid ?? "") === String(grantUuid);
+  }) ?? null;
+}
+
+function getGrantedByKnacks(spell) {
+  const flags = spell?.flags?.[SYSTEM_ID] ?? {};
+  const arr = flags?.grantedByKnackUuids;
+  return Array.isArray(arr) ? arr.map(String).filter(Boolean) : [];
+}
+
+async function createManagedSpellCopy({ actor, sourceSpell, grantUuid, grantingKnackUuid }) {
+  const itemData = foundry.utils.deepClone(sourceSpell.toObject());
+  delete itemData._id;
+
+  itemData.flags = itemData.flags ?? {};
+  itemData.flags.core = itemData.flags.core ?? {};
+
+  // Keep core.sourceId for traceability, but do NOT dedupe against manual actor spells.
+  // We dedupe only against spells that we mark as grantKind=knack.
+  itemData.flags.core.sourceId = grantUuid;
+
+  itemData.flags[SYSTEM_ID] = {
+    ...(itemData.flags[SYSTEM_ID] ?? {}),
+
+    grantKind: "knack",
+    grantSourceUuid: grantUuid,
+    grantedByKnackUuids: [grantingKnackUuid],
+  };
+
+  const [created] = await actor.createEmbeddedDocuments("Item", [itemData]);
+  return created ?? null;
+}
+
+/**
+ * Apply all spell grants from a newly-acquired knack.
+ * - Creates embedded spell copies marked as grantKind=knack.
+ * - Uses a single managed copy per grant UUID and reference-counts via grantedByKnackUuids.
+ * - Intentionally does NOT adopt or modify manually dropped spells.
+ */
+export async function applyKnackGrantsOnAcquire({ actor, knack, notify = false } = {}) {
+  if (!actor || !knack) return { createdCount: 0, updatedCount: 0 };
+  if (knack.type !== "knack") return { createdCount: 0, updatedCount: 0 };
+
+  const grants = normalizeGrants(knack);
+  if (grants.length === 0) return { createdCount: 0, updatedCount: 0 };
+
+  let createdCount = 0;
+  let updatedCount = 0;
+
+  for (const g of grants) {
+    const grantUuid = g.uuid;
+
+    const existingManaged = getManagedSpellForGrant({ actor, grantUuid });
+    if (existingManaged) {
+      const current = new Set(getGrantedByKnacks(existingManaged));
+      if (!current.has(knack.uuid)) {
+        current.add(knack.uuid);
+        await existingManaged.update({
+          [`flags.${SYSTEM_ID}.grantedByKnackUuids`]: Array.from(current),
+        });
+        updatedCount += 1;
+      }
+      continue;
+    }
+
+    let sourceSpell = null;
+    try {
+      sourceSpell = await fromUuid(grantUuid);
+    } catch (e) {
+      sourceSpell = null;
+    }
+
+    if (!sourceSpell || sourceSpell.type !== "spell") continue;
+
+    const created = await createManagedSpellCopy({
+      actor,
+      sourceSpell,
+      grantUuid,
+      grantingKnackUuid: knack.uuid,
+    });
+
+    if (created) createdCount += 1;
+  }
+
+  if (notify) {
+    if (createdCount > 0) ui.notifications?.info?.(`Granted ${createdCount} spell(s) from ${knack.name}.`);
+  }
+
+  return { createdCount, updatedCount };
+}
+
+/**
+ * Remove spell grants for a deleted/unlearned knack.
+ * - Removes the knack UUID from grantedByKnackUuids.
+ * - Deletes the spell when no granting knacks remain.
+ */
+export async function removeKnackGrantedSpellsOnDelete({ actor, knack, notify = false } = {}) {
+  if (!actor || !knack) return { deletedCount: 0, updatedCount: 0 };
+  if (knack.type !== "knack") return { deletedCount: 0, updatedCount: 0 };
+
+  const spells = actor.items?.contents ?? [];
+  const toDeleteIds = [];
+  const toUpdate = [];
+
+  for (const spell of spells) {
+    if (spell.type !== "spell") continue;
+
+    const flags = spell.flags?.[SYSTEM_ID] ?? {};
+    if (flags?.grantKind !== "knack") continue;
+
+    const current = getGrantedByKnacks(spell);
+    if (!current.includes(knack.uuid)) continue;
+
+    const next = current.filter(u => u !== knack.uuid);
+    if (next.length === 0) {
+      toDeleteIds.push(spell.id);
+    } else {
+      toUpdate.push({
+        _id: spell.id,
+        [`flags.${SYSTEM_ID}.grantedByKnackUuids`]: next,
+      });
+    }
+  }
+
+  if (toUpdate.length > 0) await actor.updateEmbeddedDocuments("Item", toUpdate);
+  if (toDeleteIds.length > 0) await actor.deleteEmbeddedDocuments("Item", toDeleteIds);
+
+  if (notify) {
+    if (toDeleteIds.length > 0) ui.notifications?.info?.(`Removed ${toDeleteIds.length} spell(s) granted by ${knack.name}.`);
+  }
+
+  return { deletedCount: toDeleteIds.length, updatedCount: toUpdate.length };
+}
+
+function rollEffectApplies({ knack, rollState }) {
+  const re = knack?.system?.rollEffects;
+  if (!re?.enabled) return false;
+
+  const normalizeSkillKey = (key) => {
+    const raw = String(key ?? "").trim();
+    if (!raw) return "";
+
+    // Canonical system skill keys (case-insensitive match).
+    const canonical = [
+      "agility",
+      "athletics",
+      "wits",
+      "presence",
+      "intuition",
+      "knowledge",
+      "resolve",
+      "meleeCombat",
+      "rangedCombat",
+      "lore",
+    ];
+    const rawLower = raw.toLowerCase();
+    const match = canonical.find(k => k.toLowerCase() === rawLower);
+    return match ?? raw;
+  };
+
+  const skillKey = normalizeSkillKey(rollState?.skillKey);
+  const rollKind = String(rollState?.rollKind ?? "complex");
+
+  const skills = Array.isArray(re.skillKeys)
+    ? re.skillKeys.map(normalizeSkillKey).filter(Boolean)
+    : ["any"];
+  const kinds = Array.isArray(re.rollKinds) ? re.rollKinds.map(String) : ["any"];
+
+  const skillOk = skills.includes("any") || skills.includes(skillKey);
+
+  // Tome rolls are mechanically just skill rolls; treat them as "complex" for v1 applicability.
+  // Keep explicit tome rollKinds working for any existing content.
+  const kindAliases = rollKind.startsWith("tome-") ? [rollKind, "complex"] : [rollKind];
+  const kindOk = kinds.includes("any") || kindAliases.some(k => kinds.includes(k));
+  return skillOk && kindOk;
+}
+
+function isKnackUsableNow(knack) {
+  const freq = String(knack?.system?.usage?.frequency ?? "passive");
+  if (freq === "passive" || freq === "unlimited") return true;
+  const remaining = Number(knack?.system?.usage?.remaining ?? 0);
+  return remaining > 0;
+}
+
+/**
+ * Returns knacks whose roll effects match the current roll, regardless of remaining uses.
+ * Use this for UX (showing exhausted-but-applicable knacks) while keeping selection
+ * validation based on `getApplicableKnacksForRoll`.
+ */
+export function getMatchingKnacksForRoll({ actor, rollState } = {}) {
+  const knacks = (actor?.items?.contents ?? []).filter(i => i.type === "knack");
+  return knacks.filter(k => rollEffectApplies({ knack: k, rollState }));
+}
+
+export function getApplicableKnacksForRoll({ actor, rollState } = {}) {
+  const knacks = getMatchingKnacksForRoll({ actor, rollState });
+  return knacks.filter(isKnackUsableNow);
+}
+
+export function buildAppliedKnackEffects({ selectedKnacks } = {}) {
+  const list = Array.isArray(selectedKnacks) ? selectedKnacks : [];
+
+  let bonusDiceDelta = 0;
+  let resultModifierDelta = 0;
+  let advantage = false;
+  let disadvantage = false;
+  let rerollAllowanceDice = 0;
+
+  const applied = [];
+
+  for (const k of list) {
+    const mod = k.system?.rollEffects?.modifier ?? {};
+
+    bonusDiceDelta += Number(mod.addBonusDice ?? 0);
+    resultModifierDelta += Number(mod.resultModifier ?? 0);
+    if (mod.advantage) advantage = true;
+    if (mod.disadvantage) disadvantage = true;
+    rerollAllowanceDice += Number(mod.rerollAllowanceDice ?? 0);
+
+    applied.push({
+      itemId: k.id,
+      itemUuid: k.uuid,
+      name: k.name,
+      tier: Number(k.system?.tier ?? 0),
+      frequency: String(k.system?.usage?.frequency ?? "passive"),
+      spent: (String(k.system?.usage?.frequency ?? "passive") !== "passive" && String(k.system?.usage?.frequency ?? "passive") !== "unlimited"),
+      effects: {
+        bonusDiceDelta: Number(mod.addBonusDice ?? 0),
+        resultModifierDelta: Number(mod.resultModifier ?? 0),
+        advantage: !!mod.advantage,
+        disadvantage: !!mod.disadvantage,
+        rerollAllowanceDice: Number(mod.rerollAllowanceDice ?? 0),
+      }
+    });
+  }
+
+  return {
+    bonusDiceDelta,
+    resultModifierDelta,
+    advantage,
+    disadvantage,
+    rerollAllowanceDice,
+    appliedKnacks: applied,
+  };
+}
+
+export async function spendKnackUses({ actor, selectedKnacks } = {}) {
+  const list = Array.isArray(selectedKnacks) ? selectedKnacks : [];
+  const updates = [];
+
+  for (const k of list) {
+    const freq = String(k.system?.usage?.frequency ?? "passive");
+    if (freq === "passive" || freq === "unlimited") continue;
+
+    const remaining = Math.max(0, Number(k.system?.usage?.remaining ?? 0));
+    if (remaining <= 0) continue;
+
+    updates.push({
+      _id: k.id,
+      "system.usage.remaining": remaining - 1,
+    });
+  }
+
+  if (updates.length > 0) {
+    await actor.updateEmbeddedDocuments("Item", updates);
+  }
+
+  return { updatedCount: updates.length };
+}
+
+export function resolveSelectedKnacks({ actor, selectedKnackIds } = {}) {
+  const ids = Array.isArray(selectedKnackIds) ? selectedKnackIds : [];
+  const byId = new Set(ids.map(String));
+  return (actor?.items?.contents ?? []).filter(i => i.type === "knack" && byId.has(i.id));
+}
+
+export function isApplicableKnackSelection({ actor, rollState, knackIds } = {}) {
+  const applicable = new Set(getApplicableKnacksForRoll({ actor, rollState }).map(k => k.id));
+  return (Array.isArray(knackIds) ? knackIds : []).every(id => applicable.has(String(id)));
+}

--- a/module/rolls/skill-roll-workflow.mjs
+++ b/module/rolls/skill-roll-workflow.mjs
@@ -204,7 +204,11 @@ export class SkillRollWorkflow {
       spellUsed: outcome.spellUsed,
       spellUuid: outcome.spellUuid,
       spellSpecialRules: outcome.spellSpecialRules,
-      spellHasSpecialRules: outcome.spellSpecialRules && outcome.spellSpecialRules.trim() !== "" // check if spellSpecialRules is not empty
+      spellHasSpecialRules: outcome.spellSpecialRules && outcome.spellSpecialRules.trim() !== "", // check if spellSpecialRules is not empty
+
+      // Knack metadata (prompt-selectable in DiceRollApp)
+      appliedKnacks: Array.isArray(state?.appliedKnacks) ? state.appliedKnacks : [],
+      knackRerollAllowanceDice: Number(state?.knackRerollAllowanceDice ?? 0) || 0,
     };
 
     return { template, chatData };

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -231,6 +231,133 @@
   }
 }
 
+// Dice roll dialog: tidy up the Knacks selector layout.
+.roll-dialog-container {
+  .dialog-footer--primary {
+    margin-top: 10px;
+    margin-bottom: 6px;
+  }
+
+  .form-group.knack-choices {
+    flex-wrap: wrap;
+    align-items: stretch;
+
+    > label {
+      flex: 0 0 100%;
+      min-width: 0;
+      margin-bottom: 2px;
+    }
+
+    > .notes {
+      flex: 0 0 100%;
+      margin: 0 0 6px 0;
+      font-size: 0.9em;
+    }
+
+    .knack-choice-row {
+      flex: 0 0 100%;
+      display: grid;
+      grid-template-columns: 16px 1fr auto;
+      column-gap: 8px;
+      align-items: start;
+      padding: 1px 0;
+    }
+
+    .knack-choice-row + .knack-choice-row {
+      border-top: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    .knack-choice-row input[type="checkbox"] {
+      margin: 2px 0 0 0;
+    }
+
+    .knack-choice-row span {
+      min-width: 0;
+      line-height: 1.15;
+      overflow-wrap: anywhere;
+    }
+
+    .knack-choice-row small.notes {
+      display: block;
+      margin: 2px 0 0 0;
+      font-size: 0.85em;
+    }
+
+    .knack-choice-row.is-checked {
+      background: rgba(114, 42, 28, 0.10);
+      border-left: 3px solid rgba(114, 42, 28, 0.6);
+      padding-left: 6px;
+    }
+
+    .knack-choice-row.is-disabled {
+      opacity: 0.75;
+    }
+
+    .knack-choice-row.is-disabled input[type="checkbox"] {
+      cursor: not-allowed;
+    }
+
+    .knack-choice-row.is-disabled .knack-availability {
+      color: rgba(114, 42, 28, 0.95);
+      font-weight: 600;
+      margin-left: 4px;
+    }
+
+    .knack-refresh {
+      margin-left: 8px;
+      height: 24px;
+      padding: 0 8px;
+      line-height: 22px;
+      font-size: 0.9em;
+      border: 1px solid rgba(0, 0, 0, 0.25);
+      background: rgba(255, 255, 255, 0.2);
+      font-family: $font-primary;
+      cursor: pointer;
+      white-space: nowrap;
+      align-self: start;
+    }
+
+    .knack-refresh:hover {
+      width: 26px;
+      height: 26px;
+      padding: 0;
+      border: 1px solid rgba(0, 0, 0, 0.18);
+      background: rgba(255, 255, 255, 0.12);
+      color: rgba(0, 0, 0, 0.75);
+      cursor: pointer;
+      align-self: start;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .knack-preview {
+      margin: 0 0 6px 0;
+      padding: 4px 6px;
+      background: rgba(255, 255, 255, 0.25);
+      border: 1px solid rgba(0, 0, 0, 0.18);
+      border-radius: 4px;
+    }
+
+    .knack-preview__title {
+      margin-bottom: 2px;
+      color: rgba(114, 42, 28, 1);
+      font-family: $font-primary;
+      font-size: 0.95em;
+    }
+
+    .knack-preview__text {
+      font-size: 0.95em;
+    }
+
+    .knack-effect {
+      margin-left: 6px;
+      font-size: 0.9em;
+      opacity: 0.9;
+    }
+  }
+}
+
 .sheet.actor,
 .sheet.item {
   .resource-group {
@@ -255,6 +382,69 @@
     padding:  5px;
     input,select{
       height: 20px;
+    }
+
+    &.knack-sheet {
+      select.knack-multiselect {
+        height: auto;
+        min-height: 120px;
+        padding: 3px 6px;
+        font-size: 1.1em;
+      }
+
+      .knack-picker {
+        width: 100%;
+      }
+
+      .knack-picker__controls {
+        display: grid;
+        grid-template-columns: 1fr 34px;
+        gap: 8px;
+        align-items: center;
+      }
+
+      .knack-picker__select {
+        width: 100%;
+        height: 28px;
+      }
+
+      .knack-picker__add {
+        width: 34px;
+        height: 28px;
+        line-height: 26px;
+        padding: 0;
+        font-weight: 700;
+        border: 1px solid rgba(0, 0, 0, 0.25);
+        background: rgba(255, 255, 255, 0.25);
+      }
+
+      .knack-picker__selected {
+        margin-top: 6px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .knack-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 2px 6px;
+        border: 1px solid rgba(0, 0, 0, 0.18);
+        background: rgba(0, 0, 0, 0.08);
+        border-radius: 4px;
+        font-family: $font-tertiary;
+        font-size: 0.95em;
+      }
+
+      .knack-pill__remove {
+        color: rgba(0, 0, 0, 0.75);
+        text-decoration: none;
+      }
+
+      .knack-pill__remove:hover {
+        color: rgba(114, 42, 28, 1);
+      }
     }
   }
 

--- a/templates/actor/parts/character-knacks.hbs
+++ b/templates/actor/parts/character-knacks.hbs
@@ -1,12 +1,28 @@
 <fieldset>
-    <legend>KNACKS <a class='item-control item-create' data-action="createItem"
+    <legend>KNACKS
+        <a class='item-control' data-action="resetAllKnackUses" title='Reset Knack Uses'>
+            <i class='fas fa-rotate-right'></i>
+        </a>
+        <a class='item-control item-create' data-action="createItem"
                         title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='knack'>
                         <i class='fas fa-plus'></i>
                     </a></legend>
     {{#each knacks as |knack|}}
     <div class="knack-entry">
         <div>
-            <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="knack{{knack._id}}">Tier {{knack.system.tier}} - {{knack.name}} </strong>
+            <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="knack{{knack._id}}">
+                Tier {{knack.system.tier}} - {{knack.name}}
+                {{#if knack.system.usage}}
+                    <small class="notes">({{knack.system.usage.frequency}}
+                        {{#if (eq knack.system.usage.frequency "oncePerTurn")}}: {{knack.system.usage.remaining}}/{{knack.system.usage.max}}{{/if}}
+                        {{#if (eq knack.system.usage.frequency "oncePerScene")}}: {{knack.system.usage.remaining}}/{{knack.system.usage.max}}{{/if}}
+                        {{#if (eq knack.system.usage.frequency "oncePerSession")}}: {{knack.system.usage.remaining}}/{{knack.system.usage.max}}{{/if}}
+                    )</small>
+                {{/if}}
+            </strong>
+            <a class='item-control' data-action="resetKnackUses" title='Reset This Knack' data-item-id='{{knack._id}}'>
+                <i class='fas fa-rotate-right'></i>
+            </a>
             <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type='
                 knack'}}' data-item-id='{{knack._id}}'>
                 <i class='fas fa-edit'></i>

--- a/templates/dice-roll-app/dialog.hbs
+++ b/templates/dice-roll-app/dialog.hbs
@@ -69,7 +69,54 @@
         <input type="text" id="spell-to-use" name="spellToUse" value="{{spellToUse.name}}" readonly>
     </div>
     {{/if}}
-    <footer class="dialog-footer">
+
+    <footer class="dialog-footer dialog-footer--primary">
         <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> Roll</button>
     </footer>
+
+    {{#if knackChoices}}
+    <hr />
+    <div class="form-group knack-choices">
+        <label>Knacks</label>
+        <div class="notes">Select Knacks to apply. Uses are spent when you roll.</div>
+
+        {{#if knackPreview.hasSelection}}
+        <div class="knack-preview">
+            <div class="knack-preview__title">Selected effects</div>
+            <div class="knack-preview__text">{{knackPreview.text}}</div>
+        </div>
+        {{/if}}
+
+        {{#each knackChoices as |k|}}
+        <div class="flexrow knack-choice-row {{#if k.checked}}is-checked{{/if}} {{#if k.disabled}}is-disabled{{/if}}">
+            <input type="checkbox" name="selectedKnackIds" value="{{k.id}}" {{#if k.checked}}checked{{/if}} {{#if k.disabled}}disabled{{/if}}>
+            <span>
+                Tier {{k.tier}} - {{k.name}}
+                {{#if k.effect}}
+                    <span class="knack-effect">— {{k.effect.text}}</span>
+                {{/if}}
+                {{#if k.availabilityNote}}
+                    <span class="knack-availability">— {{k.availabilityNote}}</span>
+                {{/if}}
+                <small class="notes">
+                    ({{k.frequency}}
+                    {{#if (eq k.frequency "passive")}}
+                    {{else}}
+                        {{#if (eq k.frequency "unlimited")}}
+                        {{else}}
+                            : {{k.remaining}}/{{k.max}}
+                        {{/if}}
+                    {{/if}})
+                </small>
+            </span>
+
+            {{#if k.showRefresh}}
+            <button type="button" class="knack-refresh" data-action="refreshKnackUses" data-item-id="{{k.id}}" title="Refresh uses" aria-label="Refresh uses">
+                <i class="fas fa-rotate-right"></i>
+            </button>
+            {{/if}}
+        </div>
+        {{/each}}
+    </div>
+    {{/if}}
 </form>

--- a/templates/item/item-knack-sheet.hbs
+++ b/templates/item/item-knack-sheet.hbs
@@ -1,9 +1,161 @@
 <section class="tab {{tabs.form.id}} {{tabs.form.cssClass}} scrollable" id="form" data-tab="{{tabs.form.id}}"
     data-group="{{tabs.form.group}}">
-    <div class="resource-group-styled">
+    <div class="resource-group-styled knack-sheet">
         <div class="form-group">
             <label for="tier" class="styled-label">Tier</label>
             <input type="number" id="tier" name="system.tier" value="{{system.tier}}">
         </div>
+
+        <hr />
+
+        <div class="resource-group knack-grants">
+            <h5 class="quick-label">Grants (Spells/Faith/Intuition)</h5>
+            <p class="notes">Drop Spell items here to have this Knack grant them on acquire.</p>
+
+            {{#if knackGrants}}
+            <ol class='items-list'>
+                <li class='item flexrow items-header'>
+                    <div class='item-name'>Name</div>
+                    <div class='item-prop'>Source</div>
+                    <div class='item-controls'></div>
+                </li>
+                {{#each knackGrants as |spell|}}
+                <li class='item flexrow' data-uuid='{{spell.uuid}}'>
+                    <div class='item-name'>{{spell.name}}</div>
+                    <div class='item-prop'>{{spell.sourceLabel}}</div>
+                    <div class='item-controls'>
+                        <a class='item-control item-edit' data-action="openUuidItem" data-uuid="{{spell.uuid}}" title='{{localize "DOCUMENT.View" type=' spell'}}'>
+                            <i class='fas fa-eye'></i>
+                        </a>
+                        <a class='item-control item-delete' data-action="removeKnackGrant" data-uuid="{{spell.uuid}}" title='{{localize "DOCUMENT.Delete" type=' spell'}}'>
+                            <i class='fas fa-trash'></i>
+                        </a>
+                    </div>
+                </li>
+                {{/each}}
+            </ol>
+            {{/if}}
+        </div>
+
+        <hr />
+
+        <h5 class="quick-label">Usage</h5>
+        <div class="form-group">
+            <label for="usage-frequency" class="styled-label">Frequency</label>
+            <select id="usage-frequency" name="system.usage.frequency">
+                <option value="passive" {{#if (eq system.usage.frequency "passive")}}selected{{/if}}>Passive</option>
+                <option value="unlimited" {{#if (eq system.usage.frequency "unlimited")}}selected{{/if}}>Unlimited</option>
+                <option value="oncePerTurn" {{#if (eq system.usage.frequency "oncePerTurn")}}selected{{/if}}>Once Per Turn</option>
+                <option value="oncePerScene" {{#if (eq system.usage.frequency "oncePerScene")}}selected{{/if}}>Once Per Scene</option>
+                <option value="oncePerSession" {{#if (eq system.usage.frequency "oncePerSession")}}selected{{/if}}>Once Per Session</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="usage-max" class="styled-label">Max Uses</label>
+            <input type="number" id="usage-max" name="system.usage.max" value="{{system.usage.max}}" min="0">
+        </div>
+        <div class="form-group">
+            <label for="usage-remaining" class="styled-label">Remaining</label>
+            <input type="number" id="usage-remaining" name="system.usage.remaining" value="{{system.usage.remaining}}" min="0">
+        </div>
+
+        <hr />
+
+        <h5 class="quick-label">Roll Effects (Prompt-Selectable)</h5>
+        <div class="form-group">
+            <label for="roll-effects-enabled" class="styled-label">Enabled</label>
+            <input type="checkbox" id="roll-effects-enabled" name="system.rollEffects.enabled" {{#if system.rollEffects.enabled}}checked{{/if}}>
+        </div>
+
+        <div class="form-group">
+            <label class="styled-label">Applies to Skills</label>
+            <div class="knack-picker" data-group="skillKeys">
+                <div class="knack-picker__controls">
+                    <select class="knack-picker__select" name="_knackSkillKey">
+                        <option value="any">Any</option>
+                        <option value="agility">{{localize "ARKHAM_HORROR.SKILL.agility"}}</option>
+                        <option value="athletics">{{localize "ARKHAM_HORROR.SKILL.athletics"}}</option>
+                        <option value="wits">{{localize "ARKHAM_HORROR.SKILL.wits"}}</option>
+                        <option value="presence">{{localize "ARKHAM_HORROR.SKILL.presence"}}</option>
+                        <option value="intuition">{{localize "ARKHAM_HORROR.SKILL.intuition"}}</option>
+                        <option value="knowledge">{{localize "ARKHAM_HORROR.SKILL.knowledge"}}</option>
+                        <option value="resolve">{{localize "ARKHAM_HORROR.SKILL.resolve"}}</option>
+                        <option value="meleeCombat">{{localize "ARKHAM_HORROR.SKILL.meleeCombat"}}</option>
+                        <option value="rangedCombat">{{localize "ARKHAM_HORROR.SKILL.rangedCombat"}}</option>
+                        <option value="lore">{{localize "ARKHAM_HORROR.SKILL.lore"}}</option>
+                    </select>
+                    <button type="button" class="knack-picker__add" data-action="addKnackRollEffectKey" data-group="skillKeys">+</button>
+                </div>
+                <div class="knack-picker__selected" aria-label="Selected skills">
+                    {{#each system.rollEffects.skillKeys as |k|}}
+                        <span class="knack-pill" data-value="{{k}}">
+                            {{#if (eq k "any")}}
+                                Any
+                            {{else}}
+                                {{localize (concat "ARKHAM_HORROR.SKILL." k)}}
+                            {{/if}}
+                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="skillKeys" data-value="{{k}}" title="Remove">
+                                <i class="fas fa-times"></i>
+                            </a>
+                        </span>
+                    {{/each}}
+                </div>
+                <div class="notes">“Any” overrides other selections.</div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="styled-label">Applies to Roll Types</label>
+            <div class="knack-picker" data-group="rollKinds">
+                <div class="knack-picker__controls">
+                    <select class="knack-picker__select" name="_knackRollKind">
+                        <option value="any">Any</option>
+                        <option value="complex">Complex</option>
+                        <option value="reaction">Reaction</option>
+                    </select>
+                    <button type="button" class="knack-picker__add" data-action="addKnackRollEffectKey" data-group="rollKinds">+</button>
+                </div>
+                <div class="knack-picker__selected" aria-label="Selected roll types">
+                    {{#each system.rollEffects.rollKinds as |k|}}
+                        <span class="knack-pill" data-value="{{k}}">
+                            {{#if (eq k "any")}}
+                                Any
+                            {{else}}
+                                {{#if (eq k "complex")}}Complex{{/if}}
+                                {{#if (eq k "reaction")}}Reaction{{/if}}
+                                {{#if (eq k "tome-understand")}}Tome: Understand{{/if}}
+                                {{#if (eq k "tome-attune")}}Tome: Attune{{/if}}
+                            {{/if}}
+                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="rollKinds" data-value="{{k}}" title="Remove">
+                                <i class="fas fa-times"></i>
+                            </a>
+                        </span>
+                    {{/each}}
+                </div>
+                <div class="notes">“Any” overrides other selections.</div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="knack-bonus-dice" class="styled-label">Bonus Dice (delta)</label>
+            <input type="number" id="knack-bonus-dice" name="system.rollEffects.modifier.addBonusDice" value="{{system.rollEffects.modifier.addBonusDice}}" min="0">
+        </div>
+        <div class="form-group">
+            <label for="knack-result-mod" class="styled-label">Result Modifier (delta)</label>
+            <input type="number" id="knack-result-mod" name="system.rollEffects.modifier.resultModifier" value="{{system.rollEffects.modifier.resultModifier}}">
+        </div>
+        <div class="form-group">
+            <label class="styled-label">Advantage</label>
+            <input type="checkbox" name="system.rollEffects.modifier.advantage" {{#if system.rollEffects.modifier.advantage}}checked{{/if}}>
+        </div>
+        <div class="form-group">
+            <label class="styled-label">Disadvantage</label>
+            <input type="checkbox" name="system.rollEffects.modifier.disadvantage" {{#if system.rollEffects.modifier.disadvantage}}checked{{/if}}>
+        </div>
+        <div class="form-group">
+            <label for="knack-reroll-allow" class="styled-label">Reroll Allowance (dice)</label>
+            <input type="number" id="knack-reroll-allow" name="system.rollEffects.modifier.rerollAllowanceDice" value="{{system.rollEffects.modifier.rerollAllowanceDice}}" min="0">
+        </div>
+
     </div>
 </section>


### PR DESCRIPTION
Knacks can now (1) track limited uses, (2) provide prompt-selectable roll modifiers with applicability rules, and (3) grant Spells/Faith/Intuition (SPELL ITEMS) to actors via UUID-driven automation.

Adds Knack data schema for usage, roll effects and UUIDS
We are extending the roll-dialog to allow selection of applicable knacks that do basic complex roll manipulation such as +1 to rolls or adv / disadvantage.

We have also extended reroll applicability through an additional flag but have not implemented any controls on rerolls yet since that can also be influenced by items etc, but we have plumbing logic now that would enable it in the future.

<img width="936" height="1288" alt="image" src="https://github.com/user-attachments/assets/33b00dc8-41fb-4d86-a9a9-69a11edead1c" />

<img width="627" height="950" alt="image" src="https://github.com/user-attachments/assets/bf137290-3265-47d3-98c2-2d96c84a4390" />