### PR TITLE
split useful items from other equipment small bug fix

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -38,6 +38,7 @@
       "Weapons": "Waffen",
       "ProtectiveEquipment": "Schutzausrüstung",
       "UsefulItems":"Nützliche Gegenstände",
+      "OtherEquipment": "Andere Ausrüstung",
       "Favors":"Gefallen",
       "Spells":"Zauber",
       "Tomes":"Bücher",

--- a/lang/en.json
+++ b/lang/en.json
@@ -37,6 +37,7 @@
       "Weapons": "Weapons",
       "ProtectiveEquipment": "Protective Equipment",
       "UsefulItems":"Useful Items",
+      "OtherEquipment": "Other Equipment",
       "Favors":"Favors",
       "Spells":"Spells",
       "Tomes":"Tomes",

--- a/module/data/item-useful-item.mjs
+++ b/module/data/item-useful-item.mjs
@@ -6,6 +6,9 @@ export default class ArkhamHorrorUsefulItem extends ArkhamHorrorItemBase {
     const fields = foundry.data.fields;
     const schema = super.defineSchema();
 
+    // Controls whether this Useful Item should be treated as having Special Rules (default true for backwards compatibility).
+    schema.hasSpecialRules = new fields.BooleanField({ required: true, nullable: false, initial: true });
+
     schema.specialRules = new fields.StringField({ required: true, blank: true });
     schema.cost = new fields.NumberField({ required: true, nullable: false, integer: false, initial: 0, min: 0 });
     schema.uses = new fields.SchemaField({

--- a/templates/actor/parts/character-mundane-resources.hbs
+++ b/templates/actor/parts/character-mundane-resources.hbs
@@ -172,7 +172,7 @@
                         </div>
                         <span>{{item.name}}</span>
                     </div>
-                    <div class='item-prop'>{{item.system.costs}}</div>
+                    <div class='item-prop'>{{item.system.cost}}</div>
                     <div class="item-prop"><input type="text" value="{{item.system.uses.current}}"
                             data-item-stat="system.uses.current" class="item-editable-stat ammo_input"> /
                         {{item.system.uses.max}}</div>
@@ -191,6 +191,55 @@
                     <div>
                         <strong>Special Rules:</strong>
                         {{{item.system.specialRules}}}
+                    </div>
+                </div>
+            </li>
+            {{/each}}
+        </ol>
+    </div>
+
+    <div class="resource-group">
+        <!-- Other Equipment -->
+        <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.OtherEquipment"}}</h5>
+        <ol class='items-list'>
+            <li class='item flexrow items-header'>
+                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
+                <div class='item-controls'>
+                    <a class='item-control item-create' data-action="createOtherEquipment"
+                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
+                        <i class='fas fa-plus'></i>
+                    </a>
+                </div>
+            </li>
+            {{#each otherEquipment as |item id|}}
+            <li class='item' data-item-id='{{item._id}}'>
+                <div class="flexrow">
+                    <div class='item-name clickable' data-action="toggleFoldableContent"
+                        data-fc-id="otherEquipment{{item._id}}">
+                        <div class='item-image'>
+                            <a class='clickable' data-roll-type='item'>
+                                <img src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
+                            </a>
+                        </div>
+                        <span>{{item.name}}</span>
+                    </div>
+                    <div class='item-prop'>{{#if item.system.cost}}{{item.system.cost}}{{else}}{{item.system.costs}}{{/if}}</div>
+                    <div class='item-controls'>
+                        <a class='item-control item-edit' data-action="editItem"
+                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' data-action="deleteItem"
+                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            <i class='fas fa-trash'></i>
+                        </a>
+                    </div>
+                </div>
+                <div class="foldable-content" data-fc-id="otherEquipment{{item._id}}">
+                    <div>
+                        <strong>Description:</strong>
+                        {{{item.system.description}}}
                     </div>
                 </div>
             </li>

--- a/templates/item/item-useful_item-sheet.hbs
+++ b/templates/item/item-useful_item-sheet.hbs
@@ -2,6 +2,10 @@
     data-group="{{tabs.form.group}}">
     <div class="resource-group-styled">
         <div class="form-group">
+            <label for="has-special-rules">Has Special Rules</label>
+            <input type="checkbox" id="has-special-rules" name="system.hasSpecialRules" {{#if system.hasSpecialRules}}checked{{/if}} />
+        </div>
+        <div class="form-group">
             <label for="weight">{{localize "ITEM.UsefulItem.weight"}}</label>
             <input type="number" id="weight" name="system.weight" value="{{system.weight}}" min="0" />
         </div>

--- a/templates/npc/parts/npc-main.hbs
+++ b/templates/npc/parts/npc-main.hbs
@@ -279,7 +279,7 @@
                         </div>
                         <span>{{item.name}}</span>
                     </div>
-                    <div class='item-prop'>{{item.system.costs}}</div>
+                    <div class='item-prop'>{{item.system.cost}}</div>
                     <div class="item-prop"><input type="text" value="{{item.system.uses.current}}"
                             data-item-stat="system.uses.current" class="item-editable-stat ammo_input"> /
                         {{item.system.uses.max}}</div>
@@ -298,6 +298,54 @@
                     <div>
                         <strong>Special Rules:</strong>
                         {{{item.system.specialRules}}}
+                    </div>
+                </div>
+            </li>
+            {{/each}}
+        </ol>
+    </div>
+    <div class="resource-group">
+        <!-- Other Equipment -->
+        <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.OtherEquipment"}}</h5>
+        <ol class='items-list'>
+            <li class='item flexrow items-header'>
+                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
+                <div class='item-controls'>
+                    <a class='item-control item-create' data-action="createOtherEquipment"
+                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
+                        <i class='fas fa-plus'></i>
+                    </a>
+                </div>
+            </li>
+            {{#each otherEquipment as |item id|}}
+            <li class='item' data-item-id='{{item._id}}'>
+                <div class="flexrow">
+                    <div class='item-name clickable' data-action="toggleFoldableContent"
+                        data-fc-id="otherEquipment{{item._id}}">
+                        <div class='item-image'>
+                            <a class='clickable' data-roll-type='item'>
+                                <img src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
+                            </a>
+                        </div>
+                        <span>{{item.name}}</span>
+                    </div>
+                    <div class='item-prop'>{{#if item.system.cost}}{{item.system.cost}}{{else}}{{item.system.costs}}{{/if}}</div>
+                    <div class='item-controls'>
+                        <a class='item-control item-edit' data-action="editItem"
+                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' data-action="deleteItem"
+                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            <i class='fas fa-trash'></i>
+                        </a>
+                    </div>
+                </div>
+                <div class="foldable-content" data-fc-id="otherEquipment{{item._id}}">
+                    <div>
+                        <strong>Description:</strong>
+                        {{{item.system.description}}}
                     </div>
                 </div>
             </li>


### PR DESCRIPTION
This splits useful items using hasSpecialRules flag, useful items auto create with this ticked TRUE right now so we shouldn't have migration issues?  Also "Other Equipment" has been added and groups all items that don't have this flag and show their description rather than Special rules in dropdown.

Additionally, this PR includes a small bug fix for a problem I found while testing which was that the #handletoggable function was looking at all documents, this would probably only be noticable to GMs but if two sheets were open with the same item ID the toggle would flip back and forth because the ID's in the DOM were identical even for the embedded version of the items.  The small fix to this function on actor and NPC fixes that by reducing scope to that sheet so that the toggle events don't "fight" eachother anymore.

I also gave the de.json translation a shot for the Other Equipment header, its probably wrong!

<img width="1415" height="783" alt="image" src="https://github.com/user-attachments/assets/e1a9404f-a1f2-4a4b-b99e-a8d180e3a2cc" />
