### PR TITLE
Npc Profile and Weaknesses

### DIFF
--- a/css/arkham-horror-rpg-fvtt.css
+++ b/css/arkham-horror-rpg-fvtt.css
@@ -1036,7 +1036,7 @@ li.chat-message.message > .message-content {
   min-height: 220px;
 }
 .system-arkham-horror-rpg-fvtt .sheet-header.npc {
-  min-height: 180px;
+  min-height: 200px;
 }
 .system-arkham-horror-rpg-fvtt .sheet-header .profile-img {
   flex: 0 0 100px;

--- a/lang/de.json
+++ b/lang/de.json
@@ -25,12 +25,16 @@
       "Dicepool": "Würfelpool",
       "Damage": "Schaden",
       "Horror": "Horror",
+      "Archetype": "Archetyp",
+      "Profile": "Profil",
+      "Size": "Größe",
       "Skills": "Fertigkeiten",
       "Insight": "Einsicht",
       "Limit": "Limit",
       "Remaining": "Verbleibend",
       "PersonalityTrait": "Persönlichkeitsmerkmal",
       "InjuriesTrauma": "Verletzungen & Trauma",
+      "Weaknesses": "Schwächen",
       "Money": "Geld",
       "Vehicle": "Fahrzeug",
       "Lodging": "Unterkunft",
@@ -69,6 +73,9 @@
       "StrainOneself":"Sich belasten",
       "RefreshDicePool":"Erneuern"
     },
+    "Warnings": {
+      "NpcKnackDropBlocked": "Nur-NPC-Kniffe können nicht zu Charakteren hinzugefügt werden."
+    },
     "SKILL": {
       "rangedCombat": "Fernkampf",
       "meleeCombat": "Nahkampf",
@@ -89,9 +96,27 @@
       "MundaneResources": "Alltägliche Ressourcen",
       "SupernaturalResources": "Übernatürliche Ressourcen",
       "Background": "Hintergrund"
+    },
+    "NPC": {
+      "Profile": {
+        "generic": "Allgemeiner NPC",
+        "named": "Benannter Charakter",
+        "supernatural": "Übernatürliche Kreatur",
+        "monstrosity": "Eldritches Monster"
+      },
+      "Size": {
+        "standard": "Standard",
+        "large": "Groß",
+        "huge": "Riesig",
+        "titanic": "Titanisch"
+      }
     }
   },
   "ITEM": {
+    "Knack": {
+      "isNPCknack": "NPC-Knack",
+      "isNPCweakness": "NPC-Schwäche"
+    },
     "Weapon": {
       "skill": "Fertigkeit",
       "damage": "Schaden",

--- a/lang/en.json
+++ b/lang/en.json
@@ -24,12 +24,16 @@
       "Dicepool": "Dicepool",
       "Damage": "Damage",
       "Horror": "Horror",
+      "Archetype": "Archetype",
+      "Profile": "Profile",
+      "Size": "Size",
       "Skills": "Skills",
       "Insight": "Insight",
       "Limit": "Limit",
       "Remaining": "Remaining",
       "PersonalityTrait": "Personality Trait",
       "InjuriesTrauma": "Injuries & Trauma",
+      "Weaknesses": "Weaknesses",
       "Money": "Money",
       "Vehicle": "Vehicle",
       "Lodging": "Lodging",
@@ -68,6 +72,9 @@
       "StrainOneself": "Strain Oneself",
       "RefreshDicePool": "Refresh"
     },
+    "Warnings": {
+      "NpcKnackDropBlocked": "NPC-only Knacks cannot be added to Characters."
+    },
     "SKILL": {
       "rangedCombat": "Ranged Combat",
       "meleeCombat": "Melee Combat",
@@ -87,12 +94,28 @@
       "Vehicle": "Vehicle",
       "MundaneResources": "Mundane Resources",
       "SupernaturalResources": "Supernatural Resources",
-      "Background": "Background",
-      "NPC": "NPC",
-      "Biography": "Biography"
+      "Background": "Background"
+    },
+    "NPC": {
+      "Profile": {
+        "generic": "Generic NPC",
+        "named": "Named Character",
+        "supernatural": "Supernatural Creature",
+        "monstrosity": "Eldritch Monstrosity"
+      },
+      "Size": {
+        "standard": "Standard",
+        "large": "Large",
+        "huge": "Huge",
+        "titanic": "Titanic"
+      }
     }
   },
   "ITEM": {
+    "Knack": {
+      "isNPCknack": "NPC Knack",
+      "isNPCweakness": "NPC Weakness"
+    },
     "Weapon": {
       "skill": "Skill",
       "damage": "Damage",
@@ -113,7 +136,6 @@
       "cost": "Cost"
     },
     "Tome": {
-      "rarity": "Rarity",
       "alternativeNames": "Alternative Names",
       "knowledgeBonus": "Knowledge Bonus",
       "rarity": "Rarity",

--- a/module/data/actor-npc.mjs
+++ b/module/data/actor-npc.mjs
@@ -4,8 +4,23 @@ export default class ArkhamHorrorNPC extends ArkhamHorrorActorBase {
 
   static defineSchema() {
     const fields = foundry.data.fields;
-    const requiredInteger = { required: true, nullable: false, integer: true };
     const schema = super.defineSchema();
+
+    schema.profile = new fields.StringField({
+      required: true,
+      nullable: false,
+      blank: false,
+      initial: "generic",
+      choices: ["generic", "named", "supernatural", "monstrosity"],
+    });
+
+    schema.size = new fields.StringField({
+      required: true,
+      nullable: false,
+      blank: false,
+      initial: "standard",
+      choices: ["standard", "large", "huge", "titanic"],
+    });
 
     schema.abilitiesDescription = new fields.StringField({ required: false, blank: true });
     

--- a/module/data/item-knack.mjs
+++ b/module/data/item-knack.mjs
@@ -8,6 +8,9 @@ export default class ArkhamHorrorKnack extends ArkhamHorrorItemBase {
     const requiredInteger = { required: true, nullable: false, integer: true };
 
     const DocumentUUIDField = fields.DocumentUUIDField ?? fields.StringField;
+
+    schema.isNPCknack = new fields.BooleanField({ required: true, nullable: false, initial: false });
+    schema.isNPCweakness = new fields.BooleanField({ required: true, nullable: false, initial: false });
     
     schema.tier = new fields.NumberField({ ...requiredInteger, initial: 0, min: 0 });
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -216,8 +216,23 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
     }
 
     async _onDropItem(event, data) {
+        // Prevent NPC-only Knacks from being acquired by Character actors via drag/drop.
+        // We treat both flags as NPC-only markers, since older/edited data might set weakness without setting isNPCknack.
+        const droppedItemType = data?.data?.type;
+        const droppedSystem = data?.data?.system;
+        if (droppedItemType === 'knack' && (droppedSystem?.isNPCknack || droppedSystem?.isNPCweakness)) {
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.NpcKnackDropBlocked'));
+            return false;
+        }
+
         try {
             const dropped = await Item.fromDropData(data);
+
+            if (dropped?.type === 'knack' && (dropped.system?.isNPCknack || dropped.system?.isNPCweakness)) {
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.NpcKnackDropBlocked'));
+                return false;
+            }
+
             if (dropped?.type === 'archetype') {
                 const updateData = {
                     'system.archetypeUuid': dropped.uuid,

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -67,8 +67,8 @@ export class ArkhamHorrorVehicleSheet extends HandlebarsApplicationMixin(ActorSh
         sheet: { // this is the group name
             tabs:
                 [
-                    { id: 'vehicle', label: 'TABS.Vehicle', group: 'sheet' },
-                    { id: 'biography', label: 'TABS.Biography', group: 'sheet' }
+                    { id: 'vehicle', label: 'ARKHAM_HORROR.TABS.Vehicle', group: 'sheet' },
+                    { id: 'biography', label: 'ARKHAM_HORROR.TABS.Biography', group: 'sheet' }
                 ],
             initial: 'vehicle'
         }

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -13,7 +13,7 @@
   min-height: 220px;
 
   &.npc {
-    min-height: 180px;
+    min-height: 200px;
   }
 
   .profile-img {

--- a/templates/item/item-knack-sheet.hbs
+++ b/templates/item/item-knack-sheet.hbs
@@ -60,6 +60,19 @@
         </div>
 
         <hr />
+        
+        <h5 class="quick-label">NPC Knack Flags</h5>
+        <div class="form-group">
+            <label for="is-npc-knack" class="styled-label">{{localize "ITEM.Knack.isNPCknack"}}</label>
+            <input type="checkbox" id="is-npc-knack" name="system.isNPCknack" {{#if system.isNPCknack}}checked{{/if}}>
+        </div>
+
+        <div class="form-group">
+            <label for="is-npc-weakness" class="styled-label">{{localize "ITEM.Knack.isNPCweakness"}}</label>
+            <input type="checkbox" id="is-npc-weakness" name="system.isNPCweakness" {{#if system.isNPCweakness}}checked{{/if}}>
+        </div>
+
+        <hr />
 
         <h5 class="quick-label">Roll Effects (Prompt-Selectable)</h5>
         <div class="form-group">

--- a/templates/npc/parts/npc-header.hbs
+++ b/templates/npc/parts/npc-header.hbs
@@ -4,29 +4,47 @@
     </div>
 
     <div class="header-fields">
-
-
         {{!-- Edit Mode Layout --}}
         <div class="title">
             <h1 class="charname"><input name="name" type="text" value="{{actor.name}}"
                     placeholder="{{localize 'MIST_ENGINE.PLACEHOLDERS.Name'}}" /></h1>
-
         </div>
-        <div class="resource-group-styled grid grid-5col">
-            <div class="archetype-entry grid-span-2">
-                <label for="system.archetype" class="styled-label">ARCHETYPE</label>
-                <input type="text" name="system.archetype" value="{{system.archetype}}" style="height: 20px;"/>
+        <div class="resource-group-styled grid grid-8col">
+            <div class="archetype-entry grid-span-5">
+                <label for="system.profile" class="styled-label">{{localize "ARKHAM_HORROR.LABELS.Profile"}}</label>
+                <select name="system.profile" style="height: 20px; width: 100%;">
+                    <option value="generic" {{#if (eq system.profile "generic")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Profile.generic"}}</option>
+                    <option value="named" {{#if (eq system.profile "named")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Profile.named"}}</option>
+                    <option value="supernatural" {{#if (eq system.profile "supernatural")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Profile.supernatural"}}</option>
+                    <option value="monstrosity" {{#if (eq system.profile "monstrosity")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Profile.monstrosity"}}</option>
+                </select>
             </div>
-            <div class="archetype-entry">
+            <div class="archetype-entry grid-span-3">
+                <label for="system.size" class="styled-label">{{localize "ARKHAM_HORROR.LABELS.Size"}}</label>
+                <select name="system.size" style="height: 20px; width: 100%;">
+                    <option value="standard" {{#if (eq system.size "standard")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Size.standard"}}</option>
+                    <option value="large" {{#if (eq system.size "large")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Size.large"}}</option>
+                    <option value="huge" {{#if (eq system.size "huge")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Size.huge"}}</option>
+                    <option value="titanic" {{#if (eq system.size "titanic")}}selected{{/if}}>{{localize "ARKHAM_HORROR.NPC.Size.titanic"}}</option>
+                </select>
+            </div>
+            <div class="archetype-entry grid-span-2">
+                <label for="system.archetype" class="styled-label">{{localize "ARKHAM_HORROR.LABELS.Archetype"}}</label>
+                <input type="text" name="system.archetype" value="{{system.archetype}}" style="height: 20px; width: 100%;" />
+            </div>
+            <div class="header-form-group grid-span-2">
                 <label for="system.dicepool.max" class="styled-label">{{localize "ARKHAM_HORROR.LABELS.Dicepool"}}</label>
                 <input type="number" class="small-input" name="system.dicepool.max" value="{{system.dicepool.max}}" data-dtype="Number" />
             </div>
-            <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.LABELS.Damage"}}</label><input type="number" name="system.damage"
-                    value="{{system.damage}}" data-dtype="Number" class="small-input" /></div>
-            <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.LABELS.Horror"}}</label><input type="number" name="system.horror"
-                    value="{{system.horror}}" data-dtype="Number" class="small-input" /></div>
+            <div class="header-form-group grid-span-2"><label>{{localize "ARKHAM_HORROR.LABELS.Damage"}}</label><input type="number" name="system.damage"
+                    value="{{system.damage}}" data-dtype="Number" class="small-input" />
+            </div>
+            <div class="header-form-group grid-span-2"><label>{{localize "ARKHAM_HORROR.LABELS.Horror"}}</label><input type="number" name="system.horror"
+                    value="{{system.horror}}" data-dtype="Number" class="small-input" />
+            </div>
         </div>
         <div class="resource-group-styled dicepool-container">
                 {{> systems/arkham-horror-rpg-fvtt/templates/actor/parts/character-dicepool.hbs}}
         </div>
+    </div>
 </header>

--- a/templates/npc/parts/npc-main.hbs
+++ b/templates/npc/parts/npc-main.hbs
@@ -22,40 +22,11 @@
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='lore'
         skillData=system.skills.lore label="LORE"}}
     </div>
-    <div class="grid grid2-col">
-        <fieldset>
-            <legend>
-                {{localize "ARKHAM_HORROR.LABELS.InjuriesTrauma"}}
-                <a class='item-control' data-action="clickedInjuryTraumaRoll" title="Roll Injury/Trauma">
-                    <i class="fa-solid fa-dice"></i>
-                </a>
-            </legend>
-            {{#each injuries as |injury|}}
-            <div class="injury-entry">
-                <div>
-                    <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="injury{{injury._id}}">
-                        {{#if (eq injury.type 'trauma')}}[TRAUMA] {{/if}}
-                        {{#if (eq injury.type 'injury')}}[INJURY] {{/if}}
-                        {{injury.name}}</strong>
-                    <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type='
-                        injury'}}' data-item-id='{{injury._id}}'>
-                        <i class='fas fa-edit'></i>
-                    </a>
-                    <a class='item-control item-delete' data-action="deleteItem"
-                        title='{{localize "DOCUMENT.Delete" type=' injury'}}' data-item-id='{{injury._id}}'>
-                        <i class='fas fa-trash'></i>
-                    </a>
-                </div>
-                <div class="foldable-content" data-fc-id="injury{{injury._id}}">
-                    {{{injury.system.description}}}
-                </div>
-            </div>
-            {{/each}}
-        </fieldset>
+    <div class="grid grid-2col">
         <div>
             <fieldset>
-                <legend>KNACKS <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='knack'>
+                <legend>KNACKS <a class='item-control item-create' data-action="createNpcKnack"
+                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
                         <i class='fas fa-plus'></i>
                     </a></legend>
                 {{#each knacks as |knack|}}
@@ -79,6 +50,67 @@
                 {{/each}}
             </fieldset>
         </div>
+
+        <div>
+            <fieldset>
+                <legend>{{localize "ARKHAM_HORROR.LABELS.Weaknesses"}}
+                    <a class='item-control item-create' data-action="createWeakness"
+                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
+                        <i class='fas fa-plus'></i>
+                    </a>
+                </legend>
+                {{#each weaknesses as |knack|}}
+                <div class="knack-entry">
+                    <div>
+                        <strong class="clickable" data-action="toggleFoldableContent"
+                            data-fc-id="weakness{{knack._id}}">{{knack.name}} </strong>
+                        <a class='item-control item-edit' data-action="editItem"
+                            title='{{localize "DOCUMENT.Update" type=' knack'}}' data-item-id='{{knack._id}}'>
+                            <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' data-action="deleteItem"
+                            title='{{localize "DOCUMENT.Delete" type=' knack'}}' data-item-id='{{knack._id}}'>
+                            <i class='fas fa-trash'></i>
+                        </a>
+                    </div>
+                    <div class="foldable-content" data-fc-id="weakness{{knack._id}}">
+                        {{{knack.system.description}}}
+                    </div>
+                </div>
+                {{/each}}
+            </fieldset>
+
+            <fieldset>
+                <legend>
+                    {{localize "ARKHAM_HORROR.LABELS.InjuriesTrauma"}}
+                    <a class='item-control' data-action="clickedInjuryTraumaRoll" title="Roll Injury/Trauma">
+                        <i class="fa-solid fa-dice"></i>
+                    </a>
+                </legend>
+                {{#each injuries as |injury|}}
+                <div class="injury-entry">
+                    <div>
+                        <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="injury{{injury._id}}">
+                            {{#if (eq injury.type 'trauma')}}[TRAUMA] {{/if}}
+                            {{#if (eq injury.type 'injury')}}[INJURY] {{/if}}
+                            {{injury.name}}</strong>
+                        <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type='
+                            injury'}}' data-item-id='{{injury._id}}'>
+                            <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' data-action="deleteItem"
+                            title='{{localize "DOCUMENT.Delete" type=' injury'}}' data-item-id='{{injury._id}}'>
+                            <i class='fas fa-trash'></i>
+                        </a>
+                    </div>
+                    <div class="foldable-content" data-fc-id="injury{{injury._id}}">
+                        {{{injury.system.description}}}
+                    </div>
+                </div>
+                {{/each}}
+            </fieldset>
+        </div>
+
     </div>
     <div class="resource-group">
         <!-- Weapons -->
@@ -351,12 +383,5 @@
             </li>
             {{/each}}
         </ol>
-    </div>
-    <div class="form-group-rich-editor mt-10">
-        <h4>Abilities</h4>
-        <prose-mirror name="system.abilitiesDescription" button="true" editable="{{editable}}" toggled="false"
-            value="{{system.abilitiesDescription}}">
-            {{{abilitiesDescriptionHTML}}}
-        </prose-mirror>
     </div>
 </section>

--- a/templates/shared/tab-biography.hbs
+++ b/templates/shared/tab-biography.hbs
@@ -9,5 +9,15 @@
         {{else}}
         {{{biographyHTML}}}
         {{/if}}
+
+        {{#if (eq actor.type "npc")}}
+        <div class="form-group-rich-editor mt-10">
+            <h4>Abilities</h4>
+            <prose-mirror name="system.abilitiesDescription" button="true" editable="{{editable}}" toggled="false"
+                value="{{system.abilitiesDescription}}">
+                {{{abilitiesDescriptionHTML}}}
+            </prose-mirror>
+        </div>
+        {{/if}}
     </div>
 </section>


### PR DESCRIPTION
This adds the ability to classify NPCs into their groups as outlined in the book materials
Generic, Named Character, Supernatural, Eldritch Monstrosity, this is currently not hooked up to automation but allows it in the future, certain knacks key off the creature type being supernatural or a monstrosity, it also allows selection of size, this too doesn't do anything but could in the future set prototype token to 10x10, 15x15 or 20x20 per the ruleset.  Also I extended the Knacks to allow for certain knacks to be "NPC Knacks" this prevents dropping them to character sheets, Knacks can also be set as Weaknesses to service the weaknesses that are on the many NPC sheets.

Finally this PR has a small bug fix where the Vehicle sheet was calling TABS. Vehicle for its localization rather than ARKHAM_HORROR.TABS.Vehicle.

<img width="941" height="861" alt="image" src="https://github.com/user-attachments/assets/93377ca7-e48b-4750-b65e-d4ea1b81f870" />

<img width="813" height="178" alt="image" src="https://github.com/user-attachments/assets/454ccaa2-b6fa-4634-8aa9-52a84c967448" />

<img width="975" height="804" alt="image" src="https://github.com/user-attachments/assets/644bf340-75bf-4175-b700-ae9ee0c33b40" />

<img width="552" height="309" alt="image" src="https://github.com/user-attachments/assets/c9a826b9-79a1-4c71-b5e4-676f3c21ad93" />

<img width="316" height="241" alt="image" src="https://github.com/user-attachments/assets/d09297c6-6c9a-4256-abe5-5481ed6314c6" />

<img width="909" height="475" alt="image" src="https://github.com/user-attachments/assets/cc2865c2-61c1-405b-b483-89fa1e8939bd" />

