### PR TITLE
massive localization sweep

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -6,10 +6,25 @@
       "Vehicle": "ArkhamHorror Vehicle Sheet",
       "NPC": "ArkhamHorror NPC Sheet"
     },
+    "Apps": {
+      "DiceRoll": {
+        "Title": "Würfelwurf"
+      },
+      "InjuryTraumaRoll": {
+        "Title": "Verletzung-/Trauma-Wurf"
+      },
+      "RerollDice": {
+        "Title": "Würfel neu würfeln"
+      },
+      "SpendInsight": {
+        "Title": "Einsicht ausgeben"
+      }
+    },
     "Item": {
       "Spell": {
-        "SpellLVL": "Level {level} Spells",
-        "AddLVL": "Add LVL {level}"
+        "difficulty": "Schwierigkeit",
+        "SpellLVL": "Zaubergrad {level}",
+        "AddLVL": "Grad {level} hinzufügen"
       }
     },
     "Effect": {
@@ -31,6 +46,8 @@
       "Skills": "Fertigkeiten",
       "Insight": "Einsicht",
       "Limit": "Limit",
+      "Max": "Max",
+      "Knacks": "Kniffe",
       "Remaining": "Verbleibend",
       "PersonalityTrait": "Persönlichkeitsmerkmal",
       "InjuriesTrauma": "Verletzungen & Trauma",
@@ -45,26 +62,164 @@
       "OtherEquipment": "Andere Ausrüstung",
       "Favors":"Gefallen",
       "Spells":"Zauber",
+      "Tome": "Foliant",
       "Tomes":"Bücher",
       "Relics":"Relikte"
+    },
+    "UNITS": {
+      "Ft": "ft"
+    },
+    "TOOLTIPS": {
+      "ExpandSpecialRules": "{itemName} - klicken, um Spezialregeln zu erweitern",
+      "OpenArchetype": "Archetyp öffnen",
+      "UnusedXP": "Ungenutzte EP",
+      "TotalXP": "Gesamt-EP"
+    },
+    "TABS": {
+      "Description": "Beschreibung",
+      "Attributes": "Attribute",
+      "Effects": "Effekte",
+      "Character": "Charakter",
+      "NPC": "NPC",
+      "Biography": "Biografie",
+      "Vehicle": "Fahrzeug",
+      "MundaneResources": "Alltägliche Ressourcen",
+      "SupernaturalResources": "Übernatürliche Ressourcen",
+      "Background": "Hintergrund",
+      "Abilities": "Andere Fähigkeiten"
+    },
+    "VEHICLE": {
+      "Cargo": "Ladung",
+      "AbilitiesDescription": "Fähigkeiten / Beschreibung"
+    },
+    "WORDS": {
+      "Of": "von"
+    },
+    "ABBR": {
+      "Dicepool": "WP"
+    },
+    "KNACK_SHEET": {
+      "SelectedSkills": "Ausgewählte Fertigkeiten",
+      "SelectedRollTypes": "Ausgewählte Wurftypen",
+      "Any": "Beliebig",
+      "AnyOverrides": "\"Beliebig\" überschreibt andere Auswahlen.",
+      "Grants": "Gewährt (Zauber/Glaube/Intuition)",
+      "GrantsHint": "Ziehe Zauber-Items hierher, damit dieser Kniff sie beim Erwerb gewährt.",
+      "Usage": "Nutzung",
+      "Frequency": "Häufigkeit",
+      "MaxUses": "Max. Verwendungen",
+      "NpcKnackFlags": "NPC-Kniff-Flags",
+      "RollEffectsPromptSelectable": "Wurf-Effekte (auswählbar im Dialog)",
+      "Enabled": "Aktiviert",
+      "AppliesToSkills": "Gilt für Fertigkeiten",
+      "RerollAllowanceDice": "Wiederholungswurf-Kontingent (Würfel)",
+      "AppliesToRollTypes": "Gilt für Wurftypen",
+      "RollKind": {
+        "Any": "Beliebig",
+        "Complex": "Komplex",
+        "Reaction": "Reaktion",
+        "TomeUnderstand": "Foliant: Verstehen",
+        "TomeAttune": "Foliant: Einstimmen"
+      },
+      "BonusDiceDelta": "Bonuswürfel (Delta)",
+      "ResultModifierDelta": "Ergebnis-Modifikator (Delta)",
+      "Remove": "Entfernen"
+    },
+    "KNACK_USAGE": {
+      "passive": "Passiv",
+      "unlimited": "Unbegrenzt",
+      "oncePerTurn": "Einmal pro Runde",
+      "oncePerScene": "Einmal pro Szene",
+      "oncePerSession": "Einmal pro Sitzung"
+    },
+    "ARCHETYPE": {
+      "SkillCaps": "Fertigkeitsobergrenzen",
+      "TierPurchaseLimits": "Stufen-Kauflimits",
+      "TierMaxLabel": "Stufe {tier} Max",
+      "TierXpCostLabel": "Stufe {tier} EP-Kosten",
+      "KnackTiers": "Kniff-Stufen",
+      "DragDropHint": "Ziehe Kniff-Items per Drag & Drop auf eine Stufe unten, um ihre UUID hinzuzufügen (ohne Einbettung). Klicke auf einen Kniff-Namen, um die Beschreibung anzuzeigen."
     },
     "DIFFICULTY":{
       "Normal": "Normal (1)",
       "Difficult": "Schwierig (2)",
       "VeryDifficult": "Sehr Schwierig (3)"
     },
+    "DIFFICULTY_CHAT": {
+      "Normal": "Normal",
+      "Difficult": "Schwierig",
+      "VeryDifficult": "Sehr<br />Schwierig"
+    },
+    "COMBAT": {
+      "EndActivePhase": "Phase {label} beenden",
+      "EndPhase": "Phase beenden",
+      "EndCombat": "Kampf beenden",
+      "BeginCombat": "Kampf beginnen",
+      "SideInvestigators": "Ermittler",
+      "SideNPCs": "NSCs",
+      "FirstSidePrompt": "Welche Seite beginnt?",
+      "FirstSideInvestigators": "Ermittler",
+      "FirstSideNPCs": "NSCs"
+    },
+    "RARITY": {
+      "common": "Häufig",
+      "uncommon": "Ungewöhnlich",
+      "rare": "Selten",
+      "unique": "Einzigartig"
+    },
+    "BACKGROUND": {
+      "PlaceOfOrigin": "Herkunftsort",
+      "FamilyAndFriends": "Familie und Freunde",
+      "Employment": "Beschäftigung",
+      "WeeklySalary": "Wöchentliches Gehalt",
+      "Biography": "Biografie",
+      "FirstSupernaturalEncounter": "Erste übernatürliche Begegnung",
+      "NotableEnemies": "Bemerkenswerte Feinde"
+    },
+    "PERSONALITY": {
+      "Positive": "Positiv",
+      "Negative": "Negativ",
+      "NoneAssigned": "Kein Persönlichkeitstrait zugewiesen. Ziehe per Drag & Drop einen hierher."
+    },
     "PROPS":{
       "Name":"Name",
+      "Quantity": "Menge",
       "Skill":"Fertigkeit",
+      "Tier": "Stufe",
+      "Rarity": "Seltenheit",
+      "HasSpecialRules": "Hat Spezialregeln",
+      "Passengers": "Passagiere",
+      "Fuel": "Treibstoff",
+      "Cost": "Kosten",
+      "MaxRange": "Max. Reichweite",
+      "CargoCapacity": "Ladekapazität",
+      "Weapon": "Waffe",
+      "Spell": "Zauber",
       "Damage": "Schaden",
       "DamageShort": "S",
       "InjuryRating":"Verletzungsgrad",
       "InjuryRatingShort":"VG",
       "Range":"Reichweite",
+      "Engaged": "Nahkampf",
       "Ammunition":"Munition",
       "Costs": "Preis",
       "Uses":"Verwendungen",
       "Difficulty":"Schwierigkeit",
+      "RollType": "Wurftyp",
+      "RollFormula": "Wurf-Formel",
+      "NumberOfDice": "Anzahl Würfel",
+      "DieSize": "Würfelgröße",
+      "RollModifier": "Wurfmodifikator",
+      "SuccessOnXPlus": "Erfolg bei X+",
+      "BonusDice": "Bonuswürfel",
+      "Penalty": "Malus",
+      "ResultModifier": "Ergebnis-Modifikator",
+      "Advantage": "Vorteil",
+      "Disadvantage": "Nachteil",
+      "XP": "EP",
+      "Benefit": "Vorteil",
+      "Declining": "Abnehmend",
+      "Losing": "Verlieren",
       "Weight":"Gewicht",
       "SpecialRules":"Spezialregeln",
       "DefensiveBenefit":"Defensiver Vorteil"
@@ -74,10 +229,277 @@
       "RefreshInsight":"Einsicht erneuern",
       "ClearDicePool":"Zurücksetzen",
       "StrainOneself":"Sich belasten",
-      "RefreshDicePool":"Erneuern"
+      "RefreshDicePool":"Erneuern",
+      "Roll": "Würfeln",
+      "ResetAllKnackUses": "Kniff-Verwendungen zurücksetzen",
+      "ResetKnackUses": "Diesen Kniff zurücksetzen",
+      "ViewEdit": "Ansehen/Bearbeiten",
+      "Remove": "Entfernen",
+      "Reload": "Nachladen",
+      "RollInjuryTrauma": "Verletzung/Trauma würfeln"
+    },
+    "Settings": {
+      "TokenShowDicePools": {
+        "Name": "Würfelpool bei Tokens anzeigen",
+        "Hint": "Zeigt den Würfelpool bei Tokens auf der Leinwand an."
+      },
+      "TokenShowDamage": {
+        "Name": "Schaden bei Tokens anzeigen",
+        "Hint": "Zeigt den Schaden bei Tokens auf der Leinwand an."
+      },
+      "TokenOverlayAbove": {
+        "Name": "Token-Overlay über dem Token",
+        "Hint": "Wenn aktiviert, werden Würfelpool/Schaden über dem Token statt darunter angezeigt."
+      },
+      "CharacterLoadCapacity": {
+        "Name": "Tragfähigkeit des Charakters",
+        "Hint": "Automatische Berechnung der Tragfähigkeit."
+      },
+      "CharacterInjuryTable": {
+        "Name": "Verletzungstabelle (Charakter)",
+        "Hint": "Wird für Verletzungswürfe verwendet."
+      },
+      "CharacterTraumaTableVariant": {
+        "Name": "Traumatabelle-Variante (Charakter)",
+        "Hint": "Wähle aus, welche Traumatabelle für Traumawürfe verwendet wird.",
+        "Choices": {
+          "Standard": "Standard",
+          "NoPersonality": "Ohne Persönlichkeit"
+        }
+      },
+      "CharacterTraumaTable": {
+        "Name": "Traumatabelle (Charakter)",
+        "Hint": "Wird für Traumawürfe verwendet."
+      },
+      "CharacterTraumaTableNoPersonality": {
+        "Name": "Traumatabelle (Charakter, ohne Persönlichkeit)",
+        "Hint": "Optionale alternative Traumatabelle mit weniger Einträgen (ohne Effekte des Persönlichkeitsmerkmals)."
+      },
+      "NpcInjuryTable": {
+        "Name": "Verletzungstabelle (NPC)",
+        "Hint": "Wird für Verletzungswürfe verwendet."
+      },
+      "NpcTraumaTable": {
+        "Name": "Traumatabelle (NPC)",
+        "Hint": "Wird für Traumawürfe verwendet."
+      }
     },
     "Warnings": {
-      "NpcKnackDropBlocked": "Nur-NPC-Kniffe können nicht zu Charakteren hinzugefügt werden."
+      "NpcKnackDropBlocked": "Nur-NPC-Kniffe können nicht zu Charakteren hinzugefügt werden.",
+
+      "PermissionRollActor": "Du hast keine Berechtigung, für diesen Akteur zu würfeln.",
+      "PermissionStrainActor": "Du hast keine Berechtigung, diesen Akteur zu belasten.",
+      "StrainRequiresDamage": "Du kannst dich nur belasten, wenn dein Würfelpool-Maximum durch Schaden reduziert ist.",
+
+      "ArchetypeKnackDropInvalid": "Ungültige Drag&Drop-Daten für einen Archetypen-Kniff.",
+      "ArchetypeRequiredForKnacks": "Lege zuerst einen Archetypen auf diesen Akteur fest, bevor Kniffe gekauft werden.",
+      "KnackDifferentArchetype": "Dieser Kniff gehört zu einem anderen Archetypen.",
+      "ActorArchetypeInvalid": "Die Archetypen-Referenz des Akteurs ist ungültig.",
+      "KnackNotAllowedTier": "Dieser Kniff ist für Stufe {tier} im Archetypen des Akteurs nicht erlaubt.",
+      "KnackTierNotPurchasable": "Für Stufe {tier} können keine Kniffe gekauft werden (Maximum: {maxPurchasable}).",
+      "KnackTierLimitReached": "Limit für Stufe {tier} erreicht ({existingTierCount}/{maxPurchasable}).",
+      "SourceKnackResolveFailed": "Der Quell-Kniff konnte nicht aufgelöst werden.",
+
+      "ActorHasNoArchetype": "Dieser Akteur hat keinen Archetypen festgelegt.",
+      "ActorArchetypeUuidResolveFailed": "Die Archetypen-UUID des Akteurs konnte nicht aufgelöst werden.",
+      "LinkedDocNotArchetype": "Das verknüpfte Dokument ist kein Archetyp.",
+      "OpenArchetypeFailed": "Archetyp konnte nicht geöffnet werden.",
+
+      "WeaponOutOfAmmo": "{itemName} hat keine Munition mehr! Bitte nachladen, bevor es verwendet wird.",
+      "ResetKnackPermission": "Du hast keine Berechtigung, die Kniffe dieses Akteurs zurückzusetzen.",
+      "RefreshKnackUsesPermission": "Du hast keine Berechtigung, die Kniff-Verwendungen dieses Akteurs zu erneuern.",
+
+      "MacroOwnedItemsOnly": "Du kannst Makro-Buttons nur für besessene Gegenstände erstellen",
+      "MacroItemNotFound": "Gegenstand {itemName} konnte nicht gefunden werden. Du musst dieses Makro eventuell löschen und neu erstellen.",
+
+      "CombatAddCombatantsFirst": "Füge zuerst Kampfteilnehmer zum Encounter hinzu (Token-Kampfstatus umschalten) und beginne dann den Kampf.",
+
+      "RerollSelectAtLeastOneDie": "Wähle mindestens einen Würfel zum erneuten Würfeln aus.",
+
+      "RollKnacksNotApplicable": "Ein oder mehrere ausgewählte Kniffe gelten nicht mehr für diesen Wurf.",
+      "RollReactionRequiresOneDie": "Reaktionswürfe erfordern 1 Würfel aus deinem Pool.",
+      "RollAdvDisadvRequiresDie": "Vorteil/Nachteil erfordert mindestens 1 gewürfelten Würfel.",
+      "RollMustRollAtLeastOneDie": "Du musst mindestens 1 Würfel würfeln.",
+      "RollPostProcessingFailed": "Nachbearbeitung nach dem Wurf ist fehlgeschlagen.",
+
+      "InjuryTraumaFallingModeInjuryOnly": "Der Fallmodus gilt nur für Verletzungswürfe.",
+      "InjuryTraumaFallingHeightMin": "Die Fallhöhe muss mindestens {minFt} ft betragen.",
+
+      "SkillRerollInvalidCard": "Diese Chatkarte kann nicht erneut gewürfelt werden.",
+      "SkillRerollActorResolveFailed": "Der Akteur für diesen Wurf konnte nicht aufgelöst werden.",
+      "SkillRerollPermission": "Du hast keine Berechtigung, diesen Wurf erneut zu würfeln.",
+      "SkillRerollNoSelectableDice": "Es wurden keine neu würfelbaren Würfel ausgewählt.",
+
+      "RollTableEmptyResultName": "Würfeltabelle '{tableName}' hat zwar einen passenden Bereich, aber einen leeren Ergebnisnamen. Lege einen Namen für das Würfeltabellen-Ergebnis fest, sonst verwendet das System die eingebauten Fallback-Tabellen.",
+      "RollTableOverflowAssumption": "Würfeltabelle '{tableName}' endet bei {tableMax}; behandle den obersten Eintrag als {tableMax}+ für Gesamt {total}.",
+
+      "ItemOpenSourceKnackGmOnly": "Nur die SL kann Quell-Kniff-Dokumente aus einem Archetypen öffnen/bearbeiten.",
+      "ItemUuidResolveFailed": "Die abgelegte UUID konnte nicht aufgelöst werden.",
+      "ItemNoSheetForDocument": "Für dieses Dokument ist kein Sheet verfügbar.",
+      "ItemOpenUuidFailed": "Das UUID-Dokument konnte nicht geöffnet werden.",
+      "ItemTomeModifySpellsGmOnly": "Nur die SL kann die Zauber eines Folianten ändern.",
+      "ItemTomeModifySpellListOrDifficultyGmOnly": "Nur die SL kann die Zauberliste oder den Verständnis-Schwierigkeitsgrad eines Folianten ändern.",
+      "ItemTomeMustBeOwnedToUnderstand": "Dieser Foliant muss einem Akteur gehören, um verstanden zu werden.",
+      "ItemTomeMustBeOwnedToAttune": "Dieser Foliant muss einem Akteur gehören, um darauf eingestimmt zu werden.",
+      "ItemTomeMustUnderstandBeforeAttune": "Du musst diesen Folianten verstehen, bevor du dich darauf einstimmen kannst.",
+      "ItemTomeClearStateGmOnly": "Nur die SL kann den verstanden/eingestimmt-Status eines Folianten zurücksetzen.",
+      "ItemArchetypeModifyAllowedKnacksGmOnly": "Nur die SL kann die erlaubten Kniffe eines Archetyps ändern.",
+      "ItemArchetypeModifyGmOnly": "Nur die SL kann einen Archetypen ändern.",
+      "ItemArchetypeDropTierRequired": "Lege den Kniff auf eine konkrete Stufe ab.",
+      "ItemArchetypeDropOnlyKnacks": "Auf einen Archetypen können nur Kniff-Gegenstände abgelegt werden.",
+      "ItemTomeDropModifyGmOnly": "Nur die SL kann Zauber zu einem Folianten hinzufügen oder entfernen.",
+      "ItemTomeDropOnlySpells": "Auf einen Folianten können nur Zauber abgelegt werden.",
+      "ItemKnackDropOnlySpells": "Auf die Kniff-Gewährungsliste können nur Zauber abgelegt werden.",
+      "ItemTomeInaccessibleSpells": "Dieser Foliant enthält {count} Zauber, die du nicht ansehen darfst."
+    },
+    "Info": {
+      "KnackAlreadyOwnedUpdated": "Kniff bereits vorhanden; Stufe wurde an den Archetypen angepasst.",
+      "ArchetypeSet": "Archetyp auf {archetypeName} gesetzt.",
+      "TomeAlreadyUnderstood": "Dieser Foliant ist bereits verstanden.",
+      "TomeNoSpellsToLearn": "Dieser Foliant enthält keine Zauber, die gelernt werden können.",
+      "TomeLearnedSpells": "Aus dem Folianten {count} Zauber gelernt.",
+      "TomeNoNewSpellsLearned": "Aus diesem Folianten wurden keine neuen Zauber gelernt.",
+      "TomeAttuned": "Auf {tomeName} eingestimmt.",
+      "TomeClearedUnderstanding": "Verständnis des Folianten zurückgesetzt.",
+      "ArchetypeKnackAlreadyAddedTier": "Kniff wurde dieser Stufe bereits hinzugefügt.",
+      "TomeSpellAlreadyInTome": "Dieser Zauber ist bereits in diesem Folianten.",
+      "KnackSpellAlreadyGranted": "Dieser Zauber wird von diesem Kniff bereits gewährt."
+    },
+    "INSIGHT": {
+      "Errors": {
+        "PermissionSpend": "Du hast keine Berechtigung, für diesen Akteur Einsicht auszugeben.",
+        "PermissionRefresh": "Du hast keine Berechtigung, für diesen Akteur Einsicht zu erneuern.",
+        "OnlyCharacterSpend": "Nur Charakter-Akteure können Einsicht ausgeben.",
+        "OnlyCharacterRefresh": "Nur Charakter-Akteure können Einsicht erneuern.",
+        "NoneRemaining": "{actorName} hat keine Einsicht mehr.",
+        "InsufficientRemaining": "{actorName} hat nicht genug verbleibende Einsicht.",
+        "AmountAtLeastOne": "Die auszugebende Einsicht muss mindestens 1 betragen."
+      }
+    },
+    "DICEPOOL": {
+      "Chat": {
+        "Refresh": "Würfelpool erneuern",
+        "Reset": "Würfelpool zurücksetzen"
+      }
+    },
+    "InjuryTrauma": {
+      "Fallback": {
+        "NoMatchingEntry": "Kein passender Tabelleneintrag",
+        "Trauma": {
+          "SubtleStrangeness": "Subtile Seltsamkeit",
+          "Shocked": "Schockiert",
+          "Stunned": "Benommen",
+          "OvercomeByHorror": "Vom Grauen überwältigt",
+          "MindUndone": "Verstand zerrüttet",
+          "LostForever": "Für immer verloren"
+        },
+        "Injury": {
+          "HeavyBlow": "Schwerer Schlag",
+          "Slowed": "Verlangsamt",
+          "NastyCut": "Übler Schnitt",
+          "Concussed": "Gehirnerschütterung",
+          "InjuredArm": "Verletzter Arm",
+          "InjuredLeg": "Verletztes Bein",
+          "LossOfASense": "Verlust eines Sinns",
+          "SeverelyInjured": "Schwer verletzt",
+          "Comatose": "Komatös",
+          "Dire": "Kritisch",
+          "Dead": "Tot"
+        }
+      }
+    },
+    "Chat": {
+      "RollResult": {
+        "ReactionRollTooltip": "Reaktionswurf",
+        "DifficultyFallback": "Schwierigkeit {successesNeeded}",
+        "Reroll": "Neu würfeln",
+        "Success": "ERFOLG",
+        "Failure": "MISSERFOLG",
+        "HorrorDiceHint": "Horrorwürfel sind schwarz markiert.",
+        "HorrorDiceTooltip": "Horrorwürfel sind schwarz markiert.",
+        "RerollDice": "Würfel neu würfeln",
+        "RollDetails": "Wurfdetails",
+        "Advantage": "Vorteil",
+        "Disadvantage": "Nachteil",
+        "Penalty": "Malus -{penalty}",
+        "Result": "Ergebnis +{resultModifier}",
+        "BonusDice": "Bonuswürfel: {bonusDice}",
+        "DroppedDice": "Fallengelassene Würfel",
+        "RawDiceResult": "Unverändertes Würfelergebnis",
+        "Successes": "Erfolge",
+        "Failures": "Fehlschläge",
+        "Trauma": "Trauma",
+        "Damage": "Schaden",
+        "InflictInjury": "Verletzung zufügen",
+        "DicePoolUnchangedReroll": "Würfelpool: unverändert (neu gewürfelt)",
+        "DicePoolChanged": "Würfelpool: {oldDicePoolValue} → {newDicePoolValue}"
+      },
+      "DicepoolReset": {
+        "Changed": "Würfelpool von {actorName} änderte sich von {oldDicePoolValue} auf {newDicePoolValue}.",
+        "HealedDamage": "{healedDamage} Schaden geheilt"
+      },
+      "Insight": {
+        "LabelSpent": "Einsicht ausgegeben",
+        "LabelRefreshed": "Einsicht erneuert",
+        "Spent": "{actorName} gab {spent} Einsicht aus ({oldRemaining} → {newRemaining}/{limit}).",
+        "Refreshed": "{actorName}s Einsicht wurde von {oldRemaining} auf {newRemaining} erneuert."
+      },
+      "InjuryTrauma": {
+        "FallingTooltip": "Fallen",
+        "StrainTooltip": "Sich belasten",
+        "StrainNote": "Wende die resultierende Verletzung am Ende des Zuges / nach 1 komplexen Aktion an.",
+        "FallingLabel": "Sturzverletzung",
+        "HeightLabel": "Höhe",
+        "Roll": "Wurf",
+        "Die": "Würfel",
+        "Dice": "Würfel",
+        "DieTotal": "Würfelsumme",
+        "Modifier": "Modifikator",
+        "Total": "Gesamt",
+        "Table": "Tabelle"
+      }
+    },
+    "Dialog": {
+      "ResetKnacks": {
+        "Title": "Kniff-Verwendungen zurücksetzen",
+        "Prompt": "Welche Kniff-Verwendungen zurücksetzen?",
+        "OncePerTurn": "Einmal pro Zug",
+        "OncePerScene": "Einmal pro Szene",
+        "OncePerSession": "Einmal pro Sitzung",
+        "All": "Alle"
+      },
+      "DiceRoll": {
+        "Knacks": "Kniffe",
+        "KnacksHint": "Wähle Kniffe aus, die angewendet werden sollen. Verwendungen werden beim Würfeln ausgegeben.",
+        "SelectedEffects": "Ausgewählte Effekte",
+        "Tier": "Stufe {tier}",
+        "RefreshUses": "Verwendungen erneuern",
+        "None": "Keine",
+        "AdvPlusDisadv": "Vorteil + Nachteil"
+      },
+      "SpendInsight": {
+        "Remaining": "Verbleibend: {remaining}/{limit}",
+        "Spend": "Ausgeben"
+      },
+      "InjuryTrauma": {
+        "RollType": "Wurftyp",
+        "Mode": "Modus",
+        "Standard": "Standard",
+        "Falling": "Fallen",
+        "Die": "Würfel",
+        "FallingHeightFt": "Fallhöhe (ft)",
+        "Modifier": "Modifikator"
+      },
+      "RerollDice": {
+        "SuccessOn": "Erfolg bei",
+        "RerollSelected": "Ausgewählte neu würfeln",
+        "DieTypeHorror": "Horror",
+        "DieTypeNormal": "Normal",
+        "Raw": "Roh",
+        "Final": "Final",
+        "Dropped": "fallen gelassen",
+        "CannotReroll": "nicht neu würfelbar"
+      }
     },
     "MONEY": {
       "Actions": {
@@ -125,16 +547,24 @@
       "resolve": "Entschlossenheit",
       "lore": "Lore"
     },
-    "TABS": {
-      "Character": "Charakter",
-      "NPC": "NPC",
-      "Biography": "Biografie",
-      "Vehicle": "Fahrzeug",
-      "MundaneResources": "Alltägliche Ressourcen",
-      "SupernaturalResources": "Übernatürliche Ressourcen",
-      "Background": "Hintergrund"
+    "SKILL_SHORT": {
+      "agility": "AGI",
+      "athletics": "ATH",
+      "wits": "WIT",
+      "presence": "PRES",
+      "intuition": "INT",
+      "knowledge": "KNOW",
+      "resolve": "RES",
+      "meleeCombat": "MELEE",
+      "rangedCombat": "RANGED",
+      "lore": "LORE"
     },
     "NPC": {
+      "NewKnack": "Neuer Kniff",
+      "NewWeakness": "Neue Schwäche",
+      "NewEquipment": "Neue Ausrüstung",
+      "Weakness": "Schwäche",
+      "Abilities": "Fähigkeiten",
       "Profile": {
         "generic": "Allgemeiner NPC",
         "named": "Benannter Charakter",
@@ -164,7 +594,9 @@
       "specialRules": "Spezialregeln",
       "ammunitionMax": "Maximale Munition",
       "reloadCost": "Nachladekosten",
-      "weight": "Gewicht"
+      "weight": "Gewicht",
+      "reloadAfterUsage": "Nach Gebrauch nachladen",
+      "isRelic": "Relikt"
     },
     "ProtectiveEquipment": {
       "defensiveBenefit": "Defensiver Vorteil",
@@ -174,11 +606,26 @@
     "Tome": {
       "alternativeNames": "Alternative Names",
       "knowledgeBonus": "Knowledge Bonus",
-      "rarity": "Rarity"
+      "rarity": "Rarity",
+      "spells": "Zauber",
+      "source": "Quelle",
+      "dropSpellHint": "(SL: ziehe einen Zauber hierher)",
+      "dropSpellTarget": "Lege Zauber-Items auf diesen Folianten (nur SL).",
+      "attunementDifficulty": "Schwierigkeit: Verstehen",
+      "difficultyNormal": "Normal (1)",
+      "difficultyDifficult": "Schwierig (2)",
+      "difficultyVeryDifficult": "Sehr Schwierig (3)",
+      "understood": "Verstanden",
+      "attuned": "Eingestimmt",
+      "understandButton": "Verstehen",
+      "attuneButton": "Einstimmen",
+      "clearUnderstoodButton": "Verstanden zurücksetzen",
+      "inaccessibleSpells": "Dieser Foliant enthält {count} Zauber, die du nicht ansehen darfst."
     },
     "UsefulItem":{
       "uses": "Uses",
-      "weight": "Weight"
+      "weight": "Weight",
+      "specialRules": "Spezialregeln"
     },
     "PersonalityTrait": {
       "positive": "Positive Trait",
@@ -189,6 +636,9 @@
       "benefit": "Benefit",
       "decliningText": "Declining",
       "losingText": "Losing"
+    },
+    "Spell": {
+      "difficulty": "Schwierigkeit"
     }
   },
   "TYPES": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,9 +6,25 @@
       "Vehicle": "ArkhamHorror Vehicle Sheet",
       "NPC": "ArkhamHorror NPC Sheet"
     },
+    "Apps": {
+      "DiceRoll": {
+        "Title": "Dice Roll"
+      },
+      "InjuryTraumaRoll": {
+        "Title": "Injury / Trauma Roll"
+      },
+      "RerollDice": {
+        "Title": "Reroll Dice"
+      },
+      "SpendInsight": {
+        "Title": "Spend Insight"
+      }
+    },
     "Item": {
       "Spell": {
-        "difficulty": "Difficulty"
+        "difficulty": "Difficulty",
+        "SpellLVL": "Spell Level {level}",
+        "AddLVL": "Add Level {level} Spell"
       }
     },
     "Effect": {
@@ -30,6 +46,8 @@
       "Skills": "Skills",
       "Insight": "Insight",
       "Limit": "Limit",
+      "Max": "Max",
+      "Knacks": "Knacks",
       "Remaining": "Remaining",
       "PersonalityTrait": "Personality Trait",
       "InjuriesTrauma": "Injuries & Trauma",
@@ -44,26 +62,164 @@
       "OtherEquipment": "Other Equipment",
       "Favors":"Favors",
       "Spells":"Spells",
+      "Tome": "Tome",
       "Tomes":"Tomes",
       "Relics":"Relics"
+    },
+    "UNITS": {
+      "Ft": "ft"
+    },
+    "TOOLTIPS": {
+      "ExpandSpecialRules": "{itemName} - click to expand special rules",
+      "OpenArchetype": "Open Archetype",
+      "UnusedXP": "Unused XP",
+      "TotalXP": "Total XP"
+    },
+    "TABS": {
+      "Description": "Description",
+      "Attributes": "Attributes",
+      "Effects": "Effects",
+      "Character": "Character",
+      "NPC": "NPC",
+      "Biography": "Biography",
+      "Vehicle": "Vehicle",
+      "MundaneResources": "Mundane Resources",
+      "SupernaturalResources": "Supernatural Resources",
+      "Background": "Background",
+      "Abilities": "Other Abilities"
+    },
+    "VEHICLE": {
+      "Cargo": "Cargo",
+      "AbilitiesDescription": "Abilities / Description"
+    },
+    "WORDS": {
+      "Of": "of"
+    },
+    "ABBR": {
+      "Dicepool": "DP"
+    },
+    "KNACK_SHEET": {
+      "SelectedSkills": "Selected skills",
+      "SelectedRollTypes": "Selected roll types",
+      "Any": "Any",
+      "AnyOverrides": "\"Any\" overrides other selections.",
+      "Grants": "Grants (Spells/Faith/Intuition)",
+      "GrantsHint": "Drop Spell items here to have this Knack grant them on acquire.",
+      "Usage": "Usage",
+      "Frequency": "Frequency",
+      "MaxUses": "Max Uses",
+      "NpcKnackFlags": "NPC Knack Flags",
+      "RollEffectsPromptSelectable": "Roll Effects (Prompt-Selectable)",
+      "Enabled": "Enabled",
+      "AppliesToSkills": "Applies to Skills",
+      "RerollAllowanceDice": "Reroll Allowance (dice)",
+      "AppliesToRollTypes": "Applies to Roll Types",
+      "RollKind": {
+        "Any": "Any",
+        "Complex": "Complex",
+        "Reaction": "Reaction",
+        "TomeUnderstand": "Tome: Understand",
+        "TomeAttune": "Tome: Attune"
+      },
+      "BonusDiceDelta": "Bonus Dice (delta)",
+      "ResultModifierDelta": "Result Modifier (delta)",
+      "Remove": "Remove"
+    },
+    "KNACK_USAGE": {
+      "passive": "Passive",
+      "unlimited": "Unlimited",
+      "oncePerTurn": "Once Per Turn",
+      "oncePerScene": "Once Per Scene",
+      "oncePerSession": "Once Per Session"
+    },
+    "ARCHETYPE": {
+      "SkillCaps": "Skill Caps",
+      "TierPurchaseLimits": "Tier Purchase Limits",
+      "TierMaxLabel": "Tier {tier} Max",
+      "TierXpCostLabel": "Tier {tier} XP Cost",
+      "KnackTiers": "Knack Tiers",
+      "DragDropHint": "Drag & drop Knack Items onto a tier below to add their UUID (no embedding). Click a knack name to view its description."
     },
     "DIFFICULTY":{
       "Normal": "Normal (1)",
       "Difficult": "Difficult (2)",
       "VeryDifficult": "Very Difficult (3)"
     },
+    "DIFFICULTY_CHAT": {
+      "Normal": "Normal",
+      "Difficult": "Difficult",
+      "VeryDifficult": "Very<br />Difficult"
+    },
+    "COMBAT": {
+      "EndActivePhase": "End {label} Phase",
+      "EndPhase": "End Phase",
+      "EndCombat": "End Combat",
+      "BeginCombat": "Begin Combat",
+      "SideInvestigators": "Investigators",
+      "SideNPCs": "NPCs",
+      "FirstSidePrompt": "Which side goes first?",
+      "FirstSideInvestigators": "Investigators",
+      "FirstSideNPCs": "NPCs"
+    },
+    "RARITY": {
+      "common": "Common",
+      "uncommon": "Uncommon",
+      "rare": "Rare",
+      "unique": "Unique"
+    },
+    "BACKGROUND": {
+      "PlaceOfOrigin": "Place of Origin",
+      "FamilyAndFriends": "Family and Friends",
+      "Employment": "Employment",
+      "WeeklySalary": "Weekly Salary",
+      "Biography": "Biography",
+      "FirstSupernaturalEncounter": "First Supernatural Encounter",
+      "NotableEnemies": "Notable Enemies"
+    },
+    "PERSONALITY": {
+      "Positive": "Positive",
+      "Negative": "Negative",
+      "NoneAssigned": "No personality trait assigned. Drag'n'drop one here."
+    },
     "PROPS":{
       "Name":"Name",
+      "Quantity": "Quantity",
       "Skill":"Skill",
+      "Tier": "Tier",
+      "Rarity": "Rarity",
+      "HasSpecialRules": "Has Special Rules",
+      "Passengers": "Passengers",
+      "Fuel": "Fuel",
+      "Cost": "Cost",
+      "MaxRange": "Max Range",
+      "CargoCapacity": "Cargo Capacity",
+      "Weapon": "Weapon",
+      "Spell": "Spell",
       "Damage": "Damage",
       "DamageShort": "D",
       "InjuryRating":"Injury Rating",
       "InjuryRatingShort":"IR",
       "Range":"Range",
+      "Engaged": "Engaged",
       "Ammunition":"Ammunition",
       "Costs":"Costs",
       "Uses":"Uses",
       "Difficulty":"Difficulty",
+      "RollType": "Roll Type",
+      "RollFormula": "Roll Formula",
+      "NumberOfDice": "Number of Dice",
+      "DieSize": "Die Size",
+      "RollModifier": "Roll Modifier",
+      "SuccessOnXPlus": "Success on X+",
+      "BonusDice": "Bonus Dice",
+      "Penalty": "Penalty",
+      "ResultModifier": "Result Modifier",
+      "Advantage": "Advantage",
+      "Disadvantage": "Disadvantage",
+      "XP": "XP",
+      "Benefit": "Benefit",
+      "Declining": "Declining",
+      "Losing": "Losing",
       "Weight":"Weight",
       "SpecialRules":"Special Rules",
       "DefensiveBenefit":"Defensive Benefit"
@@ -73,10 +229,277 @@
       "RefreshInsight": "Refresh Insight",
       "ClearDicePool": "Clear",
       "StrainOneself": "Strain Oneself",
-      "RefreshDicePool": "Refresh"
+      "RefreshDicePool": "Refresh",
+      "Roll": "Roll",
+      "ResetAllKnackUses": "Reset Knack Uses",
+      "ResetKnackUses": "Reset This Knack",
+      "ViewEdit": "View/Edit",
+      "Remove": "Remove",
+      "Reload": "Reload",
+      "RollInjuryTrauma": "Roll Injury/Trauma"
+    },
+    "Settings": {
+      "TokenShowDicePools": {
+        "Name": "Show Token Dice Pools",
+        "Hint": "Show Dice Pool on tokens on the canvas."
+      },
+      "TokenShowDamage": {
+        "Name": "Show Token Damage",
+        "Hint": "Show Damage on tokens on the canvas."
+      },
+      "TokenOverlayAbove": {
+        "Name": "Token Overlay Above Token",
+        "Hint": "If enabled, show Dice Pool/Damage above the token instead of below."
+      },
+      "CharacterLoadCapacity": {
+        "Name": "Character Load Capacity",
+        "Hint": "Automatic Load Capacity calculation."
+      },
+      "CharacterInjuryTable": {
+        "Name": "Character Injury Table",
+        "Hint": "Used for rolling injuries."
+      },
+      "CharacterTraumaTableVariant": {
+        "Name": "Character Trauma Table Variant",
+        "Hint": "Choose which character trauma table to use when rolling trauma.",
+        "Choices": {
+          "Standard": "Standard",
+          "NoPersonality": "No-Personality"
+        }
+      },
+      "CharacterTraumaTable": {
+        "Name": "Character Trauma Table",
+        "Hint": "Used for rolling trauma."
+      },
+      "CharacterTraumaTableNoPersonality": {
+        "Name": "Character Trauma Table (No-Personality)",
+        "Hint": "Optional alternate trauma table with fewer entries (no personality trait effects)."
+      },
+      "NpcInjuryTable": {
+        "Name": "NPC Injury Table",
+        "Hint": "Used for rolling injuries."
+      },
+      "NpcTraumaTable": {
+        "Name": "NPC Trauma Table",
+        "Hint": "Used for rolling trauma."
+      }
     },
     "Warnings": {
-      "NpcKnackDropBlocked": "NPC-only Knacks cannot be added to Characters."
+      "NpcKnackDropBlocked": "NPC-only Knacks cannot be added to Characters.",
+
+      "PermissionRollActor": "You do not have permission to roll for this Actor.",
+      "PermissionStrainActor": "You do not have permission to strain for this Actor.",
+      "StrainRequiresDamage": "You can only strain when your dice pool maximum is reduced by damage.",
+
+      "ArchetypeKnackDropInvalid": "Invalid archetype knack drop data.",
+      "ArchetypeRequiredForKnacks": "Set an archetype on this actor before purchasing knacks.",
+      "KnackDifferentArchetype": "This knack belongs to a different archetype.",
+      "ActorArchetypeInvalid": "Actor archetype reference is invalid.",
+      "KnackNotAllowedTier": "That knack is not allowed for Tier {tier} by the actor's archetype.",
+      "KnackTierNotPurchasable": "No Tier {tier} knacks can be purchased for this archetype (max is {maxPurchasable}).",
+      "KnackTierLimitReached": "Tier {tier} knack limit reached ({existingTierCount}/{maxPurchasable}).",
+      "SourceKnackResolveFailed": "Could not resolve the source knack item.",
+
+      "ActorHasNoArchetype": "This actor has no archetype set.",
+      "ActorArchetypeUuidResolveFailed": "Could not resolve actor archetype UUID.",
+      "LinkedDocNotArchetype": "The linked document is not an archetype.",
+      "OpenArchetypeFailed": "Failed to open archetype.",
+
+      "WeaponOutOfAmmo": "{itemName} has no ammunition left! Reload before using it.",
+      "ResetKnackPermission": "You do not have permission to reset this actor's knacks.",
+      "RefreshKnackUsesPermission": "You do not have permission to refresh knack uses for this actor.",
+
+      "MacroOwnedItemsOnly": "You can only create macro buttons for owned Items",
+      "MacroItemNotFound": "Could not find item {itemName}. You may need to delete and recreate this macro.",
+
+      "CombatAddCombatantsFirst": "Add combatants to the encounter first (toggle token combat state), then begin combat.",
+
+      "RerollSelectAtLeastOneDie": "Select at least one die to reroll.",
+
+      "RollKnacksNotApplicable": "One or more selected Knacks no longer apply to this roll.",
+      "RollReactionRequiresOneDie": "Reaction rolls require 1 die from your pool.",
+      "RollAdvDisadvRequiresDie": "Advantage/Disadvantage requires rolling at least 1 die.",
+      "RollMustRollAtLeastOneDie": "You must roll at least 1 die.",
+      "RollPostProcessingFailed": "Post-roll processing failed.",
+
+      "InjuryTraumaFallingModeInjuryOnly": "Falling mode only applies to Injury rolls.",
+      "InjuryTraumaFallingHeightMin": "Falling height must be at least {minFt} ft.",
+
+      "SkillRerollInvalidCard": "That chat card cannot be rerolled.",
+      "SkillRerollActorResolveFailed": "Could not resolve the actor for this roll.",
+      "SkillRerollPermission": "You do not have permission to reroll this roll.",
+      "SkillRerollNoSelectableDice": "No selectable dice were chosen.",
+
+      "RollTableEmptyResultName": "Roll table '{tableName}' has a matching range but an empty result name. Set the RollTable Result Name, or the system will fall back to built-in tables.",
+      "RollTableOverflowAssumption": "Roll table '{tableName}' maxes at {tableMax}; treating top entry as {tableMax}+ for total {total}.",
+
+      "ItemOpenSourceKnackGmOnly": "Only the GM can open/edit source Knack documents from an Archetype.",
+      "ItemUuidResolveFailed": "Could not resolve the dropped UUID.",
+      "ItemNoSheetForDocument": "No sheet available for that document.",
+      "ItemOpenUuidFailed": "Failed to open the UUID document.",
+      "ItemTomeModifySpellsGmOnly": "Only the GM can modify a Tome's spells.",
+      "ItemTomeModifySpellListOrDifficultyGmOnly": "Only the GM can modify a Tome's spell list or understanding difficulty.",
+      "ItemTomeMustBeOwnedToUnderstand": "This Tome must be owned by an Actor to be understood.",
+      "ItemTomeMustBeOwnedToAttune": "This Tome must be owned by an Actor to attune to it.",
+      "ItemTomeMustUnderstandBeforeAttune": "You must understand this Tome before attuning to it.",
+      "ItemTomeClearStateGmOnly": "Only the GM can clear a Tome's understood/attuned state.",
+      "ItemArchetypeModifyAllowedKnacksGmOnly": "Only the GM can modify an Archetype's allowed Knacks.",
+      "ItemArchetypeModifyGmOnly": "Only the GM can modify an Archetype.",
+      "ItemArchetypeDropTierRequired": "Drop the Knack onto a specific tier section.",
+      "ItemArchetypeDropOnlyKnacks": "Only Knack items can be dropped onto an Archetype.",
+      "ItemTomeDropModifyGmOnly": "Only the GM can add or remove spells from a Tome.",
+      "ItemTomeDropOnlySpells": "Only Spell items can be dropped onto a Tome.",
+      "ItemKnackDropOnlySpells": "Only Spell items can be dropped onto a Knack grant list.",
+      "ItemTomeInaccessibleSpells": "This Tome contains {count} spell(s) you do not have permission to view."
+    },
+    "Info": {
+      "KnackAlreadyOwnedUpdated": "Knack already owned; updated tier to match archetype.",
+      "ArchetypeSet": "Archetype set to {archetypeName}.",
+      "TomeAlreadyUnderstood": "This Tome is already understood.",
+      "TomeNoSpellsToLearn": "This Tome has no spells to learn.",
+      "TomeLearnedSpells": "Learned {count} spell(s) from the Tome.",
+      "TomeNoNewSpellsLearned": "No new spells were learned from this Tome.",
+      "TomeAttuned": "Attuned to {tomeName}.",
+      "TomeClearedUnderstanding": "Cleared Tome understanding.",
+      "ArchetypeKnackAlreadyAddedTier": "Knack already added to this tier.",
+      "TomeSpellAlreadyInTome": "That spell is already in this Tome.",
+      "KnackSpellAlreadyGranted": "That spell is already granted by this Knack."
+    },
+    "INSIGHT": {
+      "Errors": {
+        "PermissionSpend": "You do not have permission to spend Insight for this actor.",
+        "PermissionRefresh": "You do not have permission to refresh Insight for this actor.",
+        "OnlyCharacterSpend": "Only character actors can spend Insight.",
+        "OnlyCharacterRefresh": "Only character actors can refresh Insight.",
+        "NoneRemaining": "{actorName} has no Insight remaining.",
+        "InsufficientRemaining": "{actorName} does not have enough Insight remaining.",
+        "AmountAtLeastOne": "Insight spend amount must be at least 1."
+      }
+    },
+    "DICEPOOL": {
+      "Chat": {
+        "Refresh": "Dicepool Refresh",
+        "Reset": "Dicepool Reset"
+      }
+    },
+    "InjuryTrauma": {
+      "Fallback": {
+        "NoMatchingEntry": "No matching table entry",
+        "Trauma": {
+          "SubtleStrangeness": "Subtle Strangeness",
+          "Shocked": "Shocked",
+          "Stunned": "Stunned",
+          "OvercomeByHorror": "Overcome by Horror",
+          "MindUndone": "Mind Undone",
+          "LostForever": "Lost Forever"
+        },
+        "Injury": {
+          "HeavyBlow": "Heavy Blow",
+          "Slowed": "Slowed",
+          "NastyCut": "Nasty Cut",
+          "Concussed": "Concussed",
+          "InjuredArm": "Injured Arm",
+          "InjuredLeg": "Injured Leg",
+          "LossOfASense": "Loss of a Sense",
+          "SeverelyInjured": "Severely Injured",
+          "Comatose": "Comatose",
+          "Dire": "Dire",
+          "Dead": "Dead"
+        }
+      }
+    },
+    "Chat": {
+      "RollResult": {
+        "ReactionRollTooltip": "Reaction roll",
+        "DifficultyFallback": "Difficulty {successesNeeded}",
+        "Reroll": "Reroll",
+        "Success": "SUCCESS",
+        "Failure": "FAILURE",
+        "HorrorDiceHint": "Horror dice are marked in black.",
+        "HorrorDiceTooltip": "Horror dice are marked in black.",
+        "RerollDice": "Reroll dice",
+        "RollDetails": "Roll Details",
+        "Advantage": "Advantage",
+        "Disadvantage": "Disadvantage",
+        "Penalty": "Penalty -{penalty}",
+        "Result": "Result +{resultModifier}",
+        "BonusDice": "Bonus Dice: {bonusDice}",
+        "DroppedDice": "Dropped Dice",
+        "RawDiceResult": "Raw Dice Result",
+        "Successes": "Successes",
+        "Failures": "Failures",
+        "Trauma": "Trauma",
+        "Damage": "Damage",
+        "InflictInjury": "Inflict Injury",
+        "DicePoolUnchangedReroll": "Dice Pool: unchanged (reroll)",
+        "DicePoolChanged": "Dice Pool: {oldDicePoolValue} → {newDicePoolValue}"
+      },
+      "DicepoolReset": {
+        "Changed": "{actorName}'s dice pool changed from {oldDicePoolValue} to {newDicePoolValue}.",
+        "HealedDamage": "Healed {healedDamage} damage"
+      },
+      "Insight": {
+        "LabelSpent": "Insight Spent",
+        "LabelRefreshed": "Insight Refreshed",
+        "Spent": "{actorName} spent {spent} Insight ({oldRemaining} → {newRemaining}/{limit}).",
+        "Refreshed": "{actorName}'s Insight has been refreshed from {oldRemaining} to {newRemaining}."
+      },
+      "InjuryTrauma": {
+        "FallingTooltip": "Falling",
+        "StrainTooltip": "Strain Oneself",
+        "StrainNote": "apply the resulting injury at end of turn / after 1 complex action.",
+        "FallingLabel": "Falling Injury",
+        "HeightLabel": "Height",
+        "Roll": "Roll",
+        "Die": "Die",
+        "Dice": "Dice",
+        "DieTotal": "Die Total",
+        "Modifier": "Modifier",
+        "Total": "Total",
+        "Table": "Table"
+      }
+    },
+    "Dialog": {
+      "ResetKnacks": {
+        "Title": "Reset Knack Uses",
+        "Prompt": "Reset which Knack uses?",
+        "OncePerTurn": "Once Per Turn",
+        "OncePerScene": "Once Per Scene",
+        "OncePerSession": "Once Per Session",
+        "All": "All"
+      },
+      "DiceRoll": {
+        "Knacks": "Knacks",
+        "KnacksHint": "Select Knacks to apply. Uses are spent when you roll.",
+        "SelectedEffects": "Selected effects",
+        "Tier": "Tier {tier}",
+        "RefreshUses": "Refresh uses",
+        "None": "None",
+        "AdvPlusDisadv": "Adv + Disadvantage"
+      },
+      "SpendInsight": {
+        "Remaining": "Remaining: {remaining}/{limit}",
+        "Spend": "Spend"
+      },
+      "InjuryTrauma": {
+        "RollType": "Roll Type",
+        "Mode": "Mode",
+        "Standard": "Standard",
+        "Falling": "Falling",
+        "Die": "Die",
+        "FallingHeightFt": "Falling Height (ft)",
+        "Modifier": "Modifier"
+      },
+      "RerollDice": {
+        "SuccessOn": "Success on",
+        "RerollSelected": "Reroll Selected",
+        "DieTypeHorror": "Horror",
+        "DieTypeNormal": "Normal",
+        "Raw": "Raw",
+        "Final": "Final",
+        "Dropped": "dropped",
+        "CannotReroll": "cannot reroll"
+      }
     },
     "MONEY": {
       "Actions": {
@@ -124,17 +547,24 @@
       "resolve": "Resolve",
       "lore": "Lore"
     },
-    "TABS": {
-      "Character": "Character",
-      "NPC": "NPC",
-      "Biography": "Biography",
-      "Vehicle": "Vehicle",
-      "MundaneResources": "Mundane Resources",
-      "SupernaturalResources": "Supernatural Resources",
-      "Background": "Background",
-      "Abilities": "Other Abilities"
+    "SKILL_SHORT": {
+      "agility": "AGI",
+      "athletics": "ATH",
+      "wits": "WIT",
+      "presence": "PRES",
+      "intuition": "INT",
+      "knowledge": "KNOW",
+      "resolve": "RES",
+      "meleeCombat": "MELEE",
+      "rangedCombat": "RANGED",
+      "lore": "LORE"
     },
     "NPC": {
+      "NewKnack": "New Knack",
+      "NewWeakness": "New Weakness",
+      "NewEquipment": "New Equipment",
+      "Weakness": "Weakness",
+      "Abilities": "Abilities",
       "Profile": {
         "generic": "Generic NPC",
         "named": "Named Character",

--- a/module/apps/dice-roll-app.mjs
+++ b/module/apps/dice-roll-app.mjs
@@ -80,7 +80,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
     tag: "div",
     window: {
         frame: true,
-        title: "Dice Roll",
+      title: "Dice Roll",
         icon: "fa-solid fa-book-atlas",
         positioned: true,
         resizable: true,
@@ -154,6 +154,11 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
     if (options.successesNeeded !== undefined) {
       this.rollState.successesNeeded = Number.parseInt(options.successesNeeded) || 0;
     }
+
+    // Set localized window title at runtime (game.i18n is not available during static initialization).
+    this.options.window.title = game?.i18n?.localize
+      ? game.i18n.localize("ARKHAM_HORROR.Apps.DiceRoll.Title")
+      : "Dice Roll";
 
     // Reactions: exactly 1 die from pool (bonus dice and adv/disadv can add rolled dice without costing pool)
     if (this.rollState.rollKind === "reaction") {
@@ -325,7 +330,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
     if (!itemId) return;
 
     if (!(this.actor?.isOwner || game.user?.isGM)) {
-      ui.notifications?.warn?.("You do not have permission to refresh knack uses for this actor.");
+      ui.notifications?.warn?.(game.i18n.localize("ARKHAM_HORROR.Warnings.RefreshKnackUsesPermission"));
       return;
     }
 
@@ -406,7 +411,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
 
     // Validate knack selection against applicability (prevents stale selection bugs when the user changes skill).
     if (!isApplicableKnackSelection({ actor: this.actor, rollState: this.rollState, knackIds: this.rollState.selectedKnackIds })) {
-      ui.notifications.warn("One or more selected Knacks no longer apply to this roll.");
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.RollKnacksNotApplicable'));
       return;
     }
 
@@ -433,17 +438,17 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     if (this.rollState.rollKind === "reaction" && this.rollState.diceToUse !== 1) {
-        ui.notifications.warn("Reaction rolls require 1 die from your pool.");
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.RollReactionRequiresOneDie'));
         return; // keep dialog open
     }
 
     // If Adv/Disadv selected, you must be rolling at least 1 die
     const baseDice = (this.rollState.diceToUse || 0) + (this.rollState.bonusDice || 0);
     if (this.rollState.modifierAdvantage !== 0 && baseDice <= 0) {
-        ui.notifications.warn("Advantage/Disadvantage requires rolling at least 1 die.");
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.RollAdvDisadvRequiresDie'));
         return; // keep dialog open
     } else if (baseDice <= 0) {
-        ui.notifications.warn("You must roll at least 1 die.");
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.RollMustRollAtLeastOneDie'));
         return; // keep dialog open
     }
     
@@ -462,7 +467,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
           ...result
         });
       } catch (e) {
-        ui.notifications?.warn?.("Post-roll processing failed.");
+        ui.notifications?.warn?.(game.i18n.localize('ARKHAM_HORROR.Warnings.RollPostProcessingFailed'));
       }
     }
 

--- a/module/apps/injury-trauma-roll-app.mjs
+++ b/module/apps/injury-trauma-roll-app.mjs
@@ -68,6 +68,11 @@ export class InjuryTraumaRollApp extends HandlebarsApplicationMixin(ApplicationV
     this.rollState.rollSource = (options.rollSource !== undefined)
       ? String(options.rollSource ?? "")
       : "";
+
+    // Set localized window title at runtime (game.i18n is not available during static initialization).
+    this.options.window.title = game?.i18n?.localize
+      ? game.i18n.localize("ARKHAM_HORROR.Apps.InjuryTraumaRoll.Title")
+      : "Injury / Trauma Roll";
   }
 
   static getInstance(options = {}) {
@@ -188,7 +193,7 @@ export class InjuryTraumaRollApp extends HandlebarsApplicationMixin(ApplicationV
     event.preventDefault();
 
     if (!this.actor?.isOwner) {
-      ui.notifications.warn('You do not have permission to roll for this Actor.');
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.PermissionRollActor'));
       return;
     }
 
@@ -202,11 +207,11 @@ export class InjuryTraumaRollApp extends HandlebarsApplicationMixin(ApplicationV
 
     if (rollMode === "falling") {
       if (rollKind !== "injury") {
-        ui.notifications.warn('Falling mode only applies to Injury rolls.');
+        ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.InjuryTraumaFallingModeInjuryOnly'));
         return;
       }
       if (fallingHeightFt < 10) {
-        ui.notifications.warn('Falling height must be at least 10 ft.');
+        ui.notifications.warn(game.i18n.format('ARKHAM_HORROR.Warnings.InjuryTraumaFallingHeightMin', { minFt: 10 }));
         return;
       }
     }

--- a/module/apps/money-adjust-app.mjs
+++ b/module/apps/money-adjust-app.mjs
@@ -54,7 +54,7 @@ export class MoneyAdjustApp extends HandlebarsApplicationMixin(ApplicationV2) {
 
     const mode = this.mode === "spend" ? "spend" : this.mode === "set" ? "set" : "add";
     const titleKey = mode === "spend" ? "ARKHAM_HORROR.MONEY.WindowTitle.Spend" : mode === "set" ? "ARKHAM_HORROR.MONEY.WindowTitle.Set" : "ARKHAM_HORROR.MONEY.WindowTitle.Add";
-    this.options.window.title = game.i18n.localize(titleKey);
+    this.options.window.title = game?.i18n?.localize ? game.i18n.localize(titleKey) : "Money";
 
     // reset each open
     this.moneyState.amountRaw = "0.00";

--- a/module/apps/reroll-dice-app.mjs
+++ b/module/apps/reroll-dice-app.mjs
@@ -44,6 +44,11 @@ export class RerollDiceApp extends HandlebarsApplicationMixin(ApplicationV2) {
     if (options.message) this.message = options.message;
     if (options.rollFlags) this.rollFlags = options.rollFlags;
     if (typeof options.onConfirm === "function") this.onConfirm = options.onConfirm;
+
+    // Set localized window title at runtime (game.i18n is not available during static initialization).
+    this.options.window.title = game?.i18n?.localize
+      ? game.i18n.localize("ARKHAM_HORROR.Apps.RerollDice.Title")
+      : "Reroll Dice";
   }
 
   static getInstance(options = {}) {
@@ -115,7 +120,7 @@ export class RerollDiceApp extends HandlebarsApplicationMixin(ApplicationV2) {
       .filter(Number.isFinite);
 
     if (selected.length === 0) {
-      ui.notifications.warn("Select at least one die to reroll.");
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.RerollSelectAtLeastOneDie'));
       return;
     }
 

--- a/module/apps/spend-insight-app.mjs
+++ b/module/apps/spend-insight-app.mjs
@@ -49,6 +49,11 @@ export class SpendInsightApp extends HandlebarsApplicationMixin(ApplicationV2) {
 
     // Reset transient state each open
     this.insightState.amount = 1;
+
+    // Set localized window title at runtime (game.i18n is not available during static initialization).
+    this.options.window.title = game?.i18n?.localize
+      ? game.i18n.localize("ARKHAM_HORROR.Apps.SpendInsight.Title")
+      : "Spend Insight";
   }
 
   static getInstance(options = {}) {
@@ -114,13 +119,13 @@ export class SpendInsightApp extends HandlebarsApplicationMixin(ApplicationV2) {
     const amount = this.insightState.amount;
 
     if (!Number.isFinite(amount) || amount <= 0) {
-      ui.notifications.warn("Insight spend amount must be at least 1.");
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.INSIGHT.Errors.AmountAtLeastOne'));
       return;
     }
 
     const remaining = Number(this.actor?.system?.insight?.remaining) || 0;
     if (amount > remaining) {
-      ui.notifications.warn(`${this.actor.name} does not have enough Insight remaining.`);
+      ui.notifications.warn(game.i18n.format('ARKHAM_HORROR.INSIGHT.Errors.InsufficientRemaining', { actorName: this.actor.name }));
       return;
     }
 

--- a/module/arkham-horror-rpg-fvtt.mjs
+++ b/module/arkham-horror-rpg-fvtt.mjs
@@ -228,7 +228,7 @@ async function createItemMacro(data, slot) {
   if (data.type !== 'Item') return;
   if (!data.uuid.includes('Actor.') && !data.uuid.includes('Token.')) {
     return ui.notifications.warn(
-      'You can only create macro buttons for owned Items'
+      game.i18n.localize('ARKHAM_HORROR.Warnings.MacroOwnedItemsOnly')
     );
   }
   // If it is, retrieve it based on the uuid.
@@ -258,7 +258,11 @@ async function arkhamHorrorResetSceneActorDicePool() {
   for (let token of canvas.tokens.placeables) {
     const actor = token.actor;
     if (actor?.type === 'character' || actor?.type === 'npc') {
-      await refreshDicepoolAndPost({ actor, label: "Dicepool Reset", healDamage: false });
+      await refreshDicepoolAndPost({
+        actor,
+        label: game.i18n.localize("ARKHAM_HORROR.DICEPOOL.Chat.Reset"),
+        healDamage: false,
+      });
     }
   }
 }
@@ -280,7 +284,7 @@ function rollItemMacro(itemUuid) {
     if (!item || !item.parent) {
       const itemName = item?.name ?? itemUuid;
       return ui.notifications.warn(
-        `Could not find item ${itemName}. You may need to delete and recreate this macro.`
+        game.i18n.format('ARKHAM_HORROR.Warnings.MacroItemNotFound', { itemName })
       );
     }
 

--- a/module/combat/combat-tracker.mjs
+++ b/module/combat/combat-tracker.mjs
@@ -28,13 +28,17 @@ export class ArkhamHorrorCombatTracker extends foundry.applications.sidebar.tabs
     const combat = this.viewed;
     if (!combat) return context;
 
+    const localize = game?.i18n?.localize?.bind(game.i18n);
+    const investigatorsLabel = localize ? localize("ARKHAM_HORROR.COMBAT.SideInvestigators") : "Investigators";
+    const npcsLabel = localize ? localize("ARKHAM_HORROR.COMBAT.SideNPCs") : "NPCs";
+
     if (partId === "footer") {
       const active = (await combat.getFlag(FLAG_SCOPE, FLAG_ACTIVE)) ?? null;
       context.side = {
         started: combat.started,
         active,
-        activeLabel: active === "npcs" ? "NPCs" : "Investigators",
-        nextLabel: active === "npcs" ? "Investigators" : "NPCs",
+        activeLabel: active === "npcs" ? npcsLabel : investigatorsLabel,
+        nextLabel: active === "npcs" ? investigatorsLabel : npcsLabel,
         canControl: combat.isOwner
       };
     }
@@ -47,8 +51,8 @@ export class ArkhamHorrorCombatTracker extends foundry.applications.sidebar.tabs
       // Fall back to combatants list so the tracker always shows entries.
       const turns = (combat.turns?.length ? combat.turns : (combat.combatants?.contents ?? []));
       const groups = [
-        { key: "investigators", label: "Investigators", isActive: active === "investigators", entries: [] },
-        { key: "npcs", label: "NPCs", isActive: active === "npcs", entries: [] },
+        { key: "investigators", label: investigatorsLabel, isActive: active === "investigators", entries: [] },
+        { key: "npcs", label: npcsLabel, isActive: active === "npcs", entries: [] },
       ];
 
       for (const combatant of turns) {
@@ -114,7 +118,7 @@ export class ArkhamHorrorCombatTracker extends foundry.applications.sidebar.tabs
     // Use the standard Foundry flow: users add combatants explicitly (toggle token combat state).
     // Starting side combat without combatants is allowed in core, but it doesn't make sense here.
     if ((combat.combatants?.size ?? 0) === 0) {
-      ui.notifications.warn("Add combatants to the encounter first (toggle token combat state), then begin combat.");
+      ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.CombatAddCombatantsFirst'));
       return;
     }
 
@@ -155,12 +159,17 @@ export class ArkhamHorrorCombatTracker extends foundry.applications.sidebar.tabs
 
   async _promptFirstSide() {
     const { DialogV2 } = foundry.applications.api;
+    const localize = game?.i18n?.localize?.bind(game.i18n);
+    const title = localize ? localize("ARKHAM_HORROR.COMBAT.BeginCombat") : "Begin Combat";
+    const prompt = localize ? localize("ARKHAM_HORROR.COMBAT.FirstSidePrompt") : "Which side goes first?";
+    const investigatorsLabel = localize ? localize("ARKHAM_HORROR.COMBAT.FirstSideInvestigators") : "Investigators";
+    const npcsLabel = localize ? localize("ARKHAM_HORROR.COMBAT.FirstSideNPCs") : "NPCs";
     return DialogV2.wait({
-      window: { title: "Begin Combat" },
-      content: `<p>Which side goes first?</p>`,
+      window: { title },
+      content: `<p>${prompt}</p>`,
       buttons: [
-        { action: "investigators", label: "Investigators", icon: "fa-solid fa-user" },
-        { action: "npcs",          label: "NPCs",          icon: "fa-solid fa-skull" }
+        { action: "investigators", label: investigatorsLabel, icon: "fa-solid fa-user" },
+        { action: "npcs",          label: npcsLabel,          icon: "fa-solid fa-skull" }
       ],
       rejectClose: false
     });

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -33,7 +33,7 @@ export class ArkhamHorrorItem extends Item {
         if (touchesSpellUuids || touchesDifficulty) {
           deletePath(changed, 'system.spellUuids');
           deletePath(changed, 'system.attunementDifficulty');
-          ui.notifications?.warn?.('Only the GM can modify a Tome\'s spell list or understanding difficulty.');
+          ui.notifications?.warn?.(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeModifySpellListOrDifficultyGmOnly'));
         }
       }
     }

--- a/module/helpers/dicepool.mjs
+++ b/module/helpers/dicepool.mjs
@@ -3,8 +3,14 @@ import { createArkhamHorrorChatCard } from "../util/chat-utils.mjs";
 const SYSTEM_ID = "arkham-horror-rpg-fvtt";
 const TEMPLATE = `systems/${SYSTEM_ID}/templates/chat/dicepool-reset.hbs`;
 
-export async function refreshDicepoolAndPost({ actor, label = "Dicepool Refresh", healDamage = false } = {}) {
+export async function refreshDicepoolAndPost({
+  actor,
+  label = game.i18n?.localize?.("ARKHAM_HORROR.DICEPOOL.Chat.Refresh") ?? "Dicepool Refresh",
+  healDamage = false,
+} = {}) {
   if (!actor) throw new Error("refreshDicepoolAndPost requires an actor");
+
+  const safeLabel = typeof label === "string" ? label : String(label ?? "");
 
   const oldDamage = Number(actor.system?.damage ?? 0);
   const oldDicePoolValue = Number(actor.system?.dicepool?.value ?? 0);
@@ -23,7 +29,7 @@ export async function refreshDicepoolAndPost({ actor, label = "Dicepool Refresh"
   const healedDamage = Math.max(0, oldDamage - newDamage);
 
   const chatVars = {
-    label,
+    label: safeLabel,
     actorName: actor.name,
     oldDicePoolValue,
     newDicePoolValue,

--- a/module/helpers/insight.mjs
+++ b/module/helpers/insight.mjs
@@ -20,7 +20,9 @@ function buildInsightChatFlags({
     [SYSTEM_ID]: {
       schemaVersion: 1,
       rollCategory: "insight",
-      label: safeAction === "refresh" ? "Refresh Insight" : "Spend Insight",
+      label: game.i18n.localize(
+        safeAction === "refresh" ? "ARKHAM_HORROR.ACTIONS.RefreshInsight" : "ARKHAM_HORROR.ACTIONS.SpendInsight"
+      ),
       action: safeAction,
       spent: safeAction === "spend" ? asSafeInteger(spent, 0) : 0,
       oldRemaining: asSafeInteger(oldRemaining, 0),
@@ -129,7 +131,7 @@ export async function spendInsightAndPost({ actor, amount = 1, rollMode = "roll"
   }
 
   if (!(actor.isOwner || game.user?.isGM)) {
-    ui.notifications.warn("You do not have permission to spend Insight for this actor.");
+    ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.INSIGHT.Errors.PermissionSpend"));
     return {
       ok: false,
       reason: "permission",
@@ -142,13 +144,15 @@ export async function spendInsightAndPost({ actor, amount = 1, rollMode = "roll"
   }
 
   if (actor.type !== "character") {
-    ui.notifications.warn("Only character actors can spend Insight.");
+    ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.INSIGHT.Errors.OnlyCharacterSpend"));
     return await spendInsight(actor, amount);
   }
 
   const remaining = getInsightRemaining(actor);
   if (remaining <= 0) {
-    ui.notifications.warn(`${actor.name} has no Insight remaining.`);
+    ui.notifications.warn(
+      game.i18n.format("ARKHAM_HORROR.INSIGHT.Errors.NoneRemaining", { actorName: actor.name })
+    );
     return {
       ok: false,
       reason: "none",
@@ -163,11 +167,15 @@ export async function spendInsightAndPost({ actor, amount = 1, rollMode = "roll"
   const result = await spendInsight(actor, amount);
   if (!result.ok) {
     if (result.reason === "insufficient") {
-      ui.notifications.warn(`${actor.name} does not have enough Insight remaining.`);
+      ui.notifications.warn(
+        game.i18n.format("ARKHAM_HORROR.INSIGHT.Errors.InsufficientRemaining", { actorName: actor.name })
+      );
     } else if (result.reason === "amount") {
-      ui.notifications.warn("Insight spend amount must be at least 1.");
+      ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.INSIGHT.Errors.AmountAtLeastOne"));
     } else {
-      ui.notifications.warn(`${actor.name} has no Insight remaining.`);
+      ui.notifications.warn(
+        game.i18n.format("ARKHAM_HORROR.INSIGHT.Errors.NoneRemaining", { actorName: actor.name })
+      );
     }
     return result;
   }
@@ -206,7 +214,7 @@ export async function refreshInsightAndPost({ actor, rollMode = "roll", source =
   }
 
   if (!(actor.isOwner || game.user?.isGM)) {
-    ui.notifications.warn("You do not have permission to refresh Insight for this actor.");
+    ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.INSIGHT.Errors.PermissionRefresh"));
     return {
       ok: false,
       reason: "permission",
@@ -217,7 +225,7 @@ export async function refreshInsightAndPost({ actor, rollMode = "roll", source =
   }
 
   if (actor.type !== "character") {
-    ui.notifications.warn("Only character actors can refresh Insight.");
+    ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.INSIGHT.Errors.OnlyCharacterRefresh"));
     return await refreshInsight(actor);
   }
 

--- a/module/helpers/tome.mjs
+++ b/module/helpers/tome.mjs
@@ -50,7 +50,7 @@ async function createActorSpellCopiesFromUuids({ actor, tome, uuids }) {
  */
 export async function understandTomeAndLearnSpells({ actor, tome, notify = true }) {
   if (Boolean(tome?.system?.understood)) {
-    if (notify) ui.notifications?.info?.("This Tome is already understood.");
+    if (notify) ui.notifications?.info?.(game.i18n.localize("ARKHAM_HORROR.Info.TomeAlreadyUnderstood"));
     return { alreadyUnderstood: true, createdCount: 0 };
   }
 
@@ -59,7 +59,7 @@ export async function understandTomeAndLearnSpells({ actor, tome, notify = true 
   await tome.update({ "system.understood": true });
 
   if (uuids.length === 0) {
-    if (notify) ui.notifications?.info?.("This Tome has no spells to learn.");
+    if (notify) ui.notifications?.info?.(game.i18n.localize("ARKHAM_HORROR.Info.TomeNoSpellsToLearn"));
     return { alreadyUnderstood: false, createdCount: 0, hadNoSpells: true };
   }
 
@@ -67,9 +67,9 @@ export async function understandTomeAndLearnSpells({ actor, tome, notify = true 
 
   if (notify) {
     if (createdCount > 0) {
-      ui.notifications?.info?.(`Learned ${createdCount} spell(s) from the Tome.`);
+      ui.notifications?.info?.(game.i18n.format("ARKHAM_HORROR.Info.TomeLearnedSpells", { count: createdCount }));
     } else {
-      ui.notifications?.info?.("No new spells were learned from this Tome.");
+      ui.notifications?.info?.(game.i18n.localize("ARKHAM_HORROR.Info.TomeNoNewSpellsLearned"));
     }
   }
 
@@ -91,7 +91,7 @@ export async function attuneTomeExclusive({ actor, tome, notify = true }) {
   updates.push({ _id: tome.id, "system.attuned": true });
   await actor.updateEmbeddedDocuments("Item", updates);
 
-  if (notify) ui.notifications?.info?.(`Attuned to ${tome.name}.`);
+  if (notify) ui.notifications?.info?.(game.i18n.format("ARKHAM_HORROR.Info.TomeAttuned", { tomeName: tome.name }));
   return { updatedCount: updates.length };
 }
 
@@ -105,5 +105,5 @@ export async function clearTomeUnderstanding({ tome, notify = true }) {
     "system.attuned": false,
   });
 
-  if (notify) ui.notifications?.info?.("Cleared Tome understanding.");
+  if (notify) ui.notifications?.info?.(game.i18n.localize("ARKHAM_HORROR.Info.TomeClearedUnderstanding"));
 }

--- a/module/rolls/injury-trauma-workflow.mjs
+++ b/module/rolls/injury-trauma-workflow.mjs
@@ -6,33 +6,33 @@ const SYSTEM_ID = "arkham-horror-rpg-fvtt";
 const FALLBACK_TABLES = {
   trauma: {
     standard: [
-      { min: 1, max: 2, rangeLabel: "1–2", result: "Subtle Strangeness" },
-      { min: 3, max: 3, rangeLabel: "3", result: "Shocked" },
-      { min: 4, max: 4, rangeLabel: "4", result: "Stunned" },
-      { min: 5, max: 7, rangeLabel: "5–7", result: "Overcome by Horror" },
-      { min: 8, max: 10, rangeLabel: "8–10", result: "Mind Undone" },
-      { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", result: "Lost Forever" },
+      { min: 1, max: 2, rangeLabel: "1–2", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.SubtleStrangeness" },
+      { min: 3, max: 3, rangeLabel: "3", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.Shocked" },
+      { min: 4, max: 4, rangeLabel: "4", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.Stunned" },
+      { min: 5, max: 7, rangeLabel: "5–7", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.OvercomeByHorror" },
+      { min: 8, max: 10, rangeLabel: "8–10", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.MindUndone" },
+      { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.LostForever" },
     ],
     noPersonality: [
-      { min: 1, max: 2, rangeLabel: "1–2", result: "Subtle Strangeness" },
-      { min: 3, max: 4, rangeLabel: "3–4", result: "Shocked" },
-      { min: 5, max: 7, rangeLabel: "5–7", result: "Stunned" },
-      { min: 8, max: 10, rangeLabel: "8–10", result: "Mind Undone" },
-      { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", result: "Lost Forever" },
+      { min: 1, max: 2, rangeLabel: "1–2", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.SubtleStrangeness" },
+      { min: 3, max: 4, rangeLabel: "3–4", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.Shocked" },
+      { min: 5, max: 7, rangeLabel: "5–7", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.Stunned" },
+      { min: 8, max: 10, rangeLabel: "8–10", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.MindUndone" },
+      { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Trauma.LostForever" },
     ],
   },
   injury: [
-    { min: 1, max: 1, rangeLabel: "1", result: "Heavy Blow" },
-    { min: 2, max: 2, rangeLabel: "2", result: "Slowed" },
-    { min: 3, max: 3, rangeLabel: "3", result: "Nasty Cut" },
-    { min: 4, max: 4, rangeLabel: "4", result: "Concussed" },
-    { min: 5, max: 5, rangeLabel: "5", result: "Injured Arm" },
-    { min: 6, max: 6, rangeLabel: "6", result: "Injured Leg" },
-    { min: 7, max: 7, rangeLabel: "7", result: "Loss of a Sense" },
-    { min: 8, max: 8, rangeLabel: "8", result: "Severely Injured" },
-    { min: 9, max: 9, rangeLabel: "9", result: "Comatose" },
-    { min: 10, max: 10, rangeLabel: "10", result: "Dire" },
-    { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", result: "Dead" },
+    { min: 1, max: 1, rangeLabel: "1", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.HeavyBlow" },
+    { min: 2, max: 2, rangeLabel: "2", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.Slowed" },
+    { min: 3, max: 3, rangeLabel: "3", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.NastyCut" },
+    { min: 4, max: 4, rangeLabel: "4", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.Concussed" },
+    { min: 5, max: 5, rangeLabel: "5", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.InjuredArm" },
+    { min: 6, max: 6, rangeLabel: "6", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.InjuredLeg" },
+    { min: 7, max: 7, rangeLabel: "7", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.LossOfASense" },
+    { min: 8, max: 8, rangeLabel: "8", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.SeverelyInjured" },
+    { min: 9, max: 9, rangeLabel: "9", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.Comatose" },
+    { min: 10, max: 10, rangeLabel: "10", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.Dire" },
+    { min: 11, max: Number.POSITIVE_INFINITY, rangeLabel: "11+", resultKey: "ARKHAM_HORROR.InjuryTrauma.Fallback.Injury.Dead" },
   ],
 };
 
@@ -64,6 +64,12 @@ function lookupFallbackEntry(kind, traumaVariant, total) {
   }
   const entries = FALLBACK_TABLES.injury;
   return entries.find(e => t >= e.min && t <= e.max) ?? null;
+}
+
+function localizeFallbackResultName(entry) {
+  const key = entry?.resultKey;
+  if (!key) return game.i18n.localize("ARKHAM_HORROR.InjuryTrauma.Fallback.NoMatchingEntry");
+  return game.i18n.localize(key);
 }
 
 function warnOnce(key, message) {
@@ -187,12 +193,12 @@ export class InjuryTraumaWorkflow {
     // This protects against macros/future automation calling the workflow directly.
     if (rollMode === "falling") {
       if (rollKind !== "injury") {
-        const msg = "Falling mode only applies to Injury rolls.";
+        const msg = game.i18n.localize("ARKHAM_HORROR.Warnings.InjuryTraumaFallingModeInjuryOnly");
         warnOnce(`${SYSTEM_ID}|invalidFallingKind`, `[${SYSTEM_ID}] ${msg}`);
         throw new Error(msg);
       }
       if (fallingHeightFt < 10) {
-        const msg = "Falling height must be at least 10 ft.";
+        const msg = game.i18n.format("ARKHAM_HORROR.Warnings.InjuryTraumaFallingHeightMin", { minFt: 10 });
         warnOnce(`${SYSTEM_ID}|invalidFallingHeight`, `[${SYSTEM_ID}] ${msg}`);
         throw new Error(msg);
       }
@@ -228,14 +234,20 @@ export class InjuryTraumaWorkflow {
       if (resolved?.missingName) {
         warnOnce(
           `${SYSTEM_ID}|missingName|${primaryTableId}`,
-          `[${SYSTEM_ID}] RollTable '${table?.name ?? primaryTableId}' has a matching range but empty result name. Set the RollTable Result Name, or the system will fall back to built-in tables.`
+          game.i18n.format("ARKHAM_HORROR.Warnings.RollTableEmptyResultName", {
+            tableName: table?.name ?? primaryTableId,
+          })
         );
         resolved = null;
       }
       if (resolved?.usedOverflowAssumption) {
         warnOnce(
           `${SYSTEM_ID}|overflow|${primaryTableId}`,
-          `[${SYSTEM_ID}] RollTable '${table?.name ?? primaryTableId}' maxes at ${resolved.tableMax}; treating top entry as ${resolved.tableMax}+ for total ${total}.`
+          game.i18n.format("ARKHAM_HORROR.Warnings.RollTableOverflowAssumption", {
+            tableName: table?.name ?? primaryTableId,
+            tableMax: resolved.tableMax,
+            total,
+          })
         );
       }
     }
@@ -247,14 +259,20 @@ export class InjuryTraumaWorkflow {
       if (resolved?.missingName) {
         warnOnce(
           `${SYSTEM_ID}|missingName|${characterFallbackTableId}`,
-          `[${SYSTEM_ID}] RollTable '${table?.name ?? characterFallbackTableId}' has a matching range but empty result name. Set the RollTable Result Name, or the system will fall back to built-in tables.`
+          game.i18n.format("ARKHAM_HORROR.Warnings.RollTableEmptyResultName", {
+            tableName: table?.name ?? characterFallbackTableId,
+          })
         );
         resolved = null;
       }
       if (resolved?.usedOverflowAssumption) {
         warnOnce(
           `${SYSTEM_ID}|overflow|${characterFallbackTableId}`,
-          `[${SYSTEM_ID}] RollTable '${table?.name ?? characterFallbackTableId}' maxes at ${resolved.tableMax}; treating top entry as ${resolved.tableMax}+ for total ${total}.`
+          game.i18n.format("ARKHAM_HORROR.Warnings.RollTableOverflowAssumption", {
+            tableName: table?.name ?? characterFallbackTableId,
+            tableMax: resolved.tableMax,
+            total,
+          })
         );
       }
     }
@@ -263,7 +281,7 @@ export class InjuryTraumaWorkflow {
     const fallbackEntry = lookupFallbackEntry(rollKind, traumaVariant, total);
     const entry = resolved
       ? { rangeLabel: resolved.rangeLabel, resultName: resolved.resultName, resultDescription: resolved.resultDescription }
-      : { rangeLabel: fallbackEntry?.rangeLabel, resultName: fallbackEntry?.result, resultDescription: "" };
+      : { rangeLabel: fallbackEntry?.rangeLabel, resultName: localizeFallbackResultName(fallbackEntry), resultDescription: "" };
 
     return {
       rollKind,
@@ -280,7 +298,7 @@ export class InjuryTraumaWorkflow {
       modifier,
       total,
       tableRange: entry?.rangeLabel ?? "—",
-      tableResultName: entry?.resultName ?? "No matching table entry",
+      tableResultName: entry?.resultName ?? game.i18n.localize("ARKHAM_HORROR.InjuryTrauma.Fallback.NoMatchingEntry"),
       tableResultDescription: entry?.resultDescription ?? "",
     };
   }
@@ -288,7 +306,7 @@ export class InjuryTraumaWorkflow {
   buildChat({ actor, outcome }) {
     const template = `systems/${SYSTEM_ID}/templates/chat/injury-trauma-roll-card.hbs`;
 
-    const rollKindLabel = outcome.rollKind === "trauma" ? "Trauma" : "Injury";
+    const rollKindLabel = game.i18n.localize(`TYPES.Item.${outcome.rollKind === "trauma" ? "trauma" : "injury"}`);
 
     const chatData = {
       actorName: actor?.name ?? "",

--- a/module/rolls/skill-reroll-workflow.mjs
+++ b/module/rolls/skill-reroll-workflow.mjs
@@ -35,16 +35,16 @@ export class SkillRerollWorkflow {
   static fromMessage({ message, actor = null, selectedIndices = [] } = {}) {
     const rollFlags = message?.flags?.[SYSTEM_ID];
     if (!rollFlags || rollFlags.rollCategory !== "skill") {
-      throw new Error("That chat card cannot be rerolled.");
+      throw new Error(game.i18n.localize("ARKHAM_HORROR.Warnings.SkillRerollInvalidCard"));
     }
 
     const resolvedActor = actor ?? resolveActorFromMessage(message);
     if (!resolvedActor) {
-      throw new Error("Could not resolve the actor for this roll.");
+      throw new Error(game.i18n.localize("ARKHAM_HORROR.Warnings.SkillRerollActorResolveFailed"));
     }
 
     if (!canUserReroll({ actor: resolvedActor })) {
-      throw new Error("You do not have permission to reroll this roll.");
+      throw new Error(game.i18n.localize("ARKHAM_HORROR.Warnings.SkillRerollPermission"));
     }
 
     return new SkillRerollWorkflow({
@@ -72,7 +72,7 @@ export class SkillRerollWorkflow {
       .filter(({ d, idx }) => chosen.has(idx) && isSelectable(d));
 
     if (targets.length === 0) {
-      throw new Error("No selectable dice were chosen.");
+      throw new Error(game.i18n.localize("ARKHAM_HORROR.Warnings.SkillRerollNoSelectableDice"));
     }
 
     const normalIndices = targets.filter((x) => !x.d.isHorror).map((x) => x.idx);

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -399,7 +399,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         // Archetype knacks are UUID references (not embedded). Opening their sheets for players is risky because it
         // can lead to editing the source document (world/compendium) rather than an owned copy.
         if (this.document.type === 'archetype' && !(game.user?.isGM ?? false)) {
-            ui.notifications.warn('Only the GM can open/edit source Knack documents from an Archetype.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemOpenSourceKnackGmOnly'));
             return;
         }
         const uuid = target.dataset.uuid;
@@ -408,7 +408,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         try {
             const doc = await fromUuid(uuid);
             if (!doc) {
-                ui.notifications.warn('Could not resolve the dropped UUID.');
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemUuidResolveFailed'));
                 return;
             }
             if (doc.sheet) {
@@ -420,9 +420,9 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
                 }
                 return;
             }
-            ui.notifications.warn('No sheet available for that document.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemNoSheetForDocument'));
         } catch (e) {
-            ui.notifications.warn('Failed to open the UUID document.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemOpenUuidFailed'));
         }
     }
 
@@ -430,7 +430,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         event.preventDefault();
         if (this.document.type !== 'tome') return;
         if (!(game.user?.isGM ?? false)) {
-            ui.notifications.warn('Only the GM can modify a Tome\'s spells.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeModifySpellsGmOnly'));
             return;
         }
 
@@ -462,15 +462,15 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         if (this.document.type !== 'tome') return;
         const actor = this.document.actor;
         if (!actor) {
-            ui.notifications.warn('This Tome must be owned by an Actor to be understood.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeMustBeOwnedToUnderstand'));
             return;
         }
         if (!actor.isOwner) {
-            ui.notifications.warn('You do not have permission to roll for this Actor.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.PermissionRollActor'));
             return;
         }
         if (Boolean(this.document.system?.understood)) {
-            ui.notifications.info('This Tome is already understood.');
+            ui.notifications.info(game.i18n.localize('ARKHAM_HORROR.Info.TomeAlreadyUnderstood'));
             return;
         }
 
@@ -505,15 +505,15 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         if (this.document.type !== 'tome') return;
         const actor = this.document.actor;
         if (!actor) {
-            ui.notifications.warn('This Tome must be owned by an Actor to attune to it.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeMustBeOwnedToAttune'));
             return;
         }
         if (!actor.isOwner) {
-            ui.notifications.warn('You do not have permission to roll for this Actor.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.PermissionRollActor'));
             return;
         }
         if (!Boolean(this.document.system?.understood)) {
-            ui.notifications.warn('You must understand this Tome before attuning to it.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeMustUnderstandBeforeAttune'));
             return;
         }
 
@@ -544,7 +544,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         event.preventDefault();
         if (this.document.type !== 'tome') return;
         if (!(game.user?.isGM ?? false)) {
-            ui.notifications.warn("Only the GM can clear a Tome's understood/attuned state.");
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeClearStateGmOnly'));
             return;
         }
 
@@ -557,7 +557,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         event.preventDefault();
         if (this.document.type !== 'archetype') return;
         if (!(game.user?.isGM ?? false)) {
-            ui.notifications.warn('Only the GM can modify an Archetype\'s allowed Knacks.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemArchetypeModifyAllowedKnacksGmOnly'));
             return;
         }
 
@@ -575,7 +575,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
 
     async #addKnackUuidToTier(tier, uuid) {
         if (!(game.user?.isGM ?? false)) {
-            ui.notifications.warn('Only the GM can modify an Archetype\'s allowed Knacks.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemArchetypeModifyAllowedKnacksGmOnly'));
             return;
         }
         const structuredPath = `system.knackTiers.${tier}.allowedKnacks`;
@@ -583,7 +583,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         const currentStructured = foundry.utils.getProperty(this.document, structuredPath) ?? [];
 
         if (currentStructured.some(e => e?.uuid === uuid)) {
-            ui.notifications.info("Knack already added to this tier.");
+            ui.notifications.info(game.i18n.localize('ARKHAM_HORROR.Info.ArchetypeKnackAlreadyAddedTier'));
             return;
         }
 
@@ -693,7 +693,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         // Archetype: only store UUID references to dropped knacks (no embedding)
         if (this.document.type === 'archetype' && data?.type === 'Item') {
             if (!(game.user?.isGM ?? false)) {
-                ui.notifications.warn('Only the GM can modify an Archetype.');
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemArchetypeModifyGmOnly'));
                 return;
             }
 
@@ -701,13 +701,13 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
                 ?? event.currentTarget?.closest?.('.archetype-tier-drop');
             const tier = Number(tierEl?.dataset?.archetypeTier);
             if (!tier) {
-                ui.notifications.warn('Drop the Knack onto a specific tier section.');
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemArchetypeDropTierRequired'));
                 return;
             }
 
             const dropped = await Item.fromDropData(data);
             if (!dropped || dropped.type !== 'knack') {
-                ui.notifications.warn('Only Knack items can be dropped onto an Archetype.');
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemArchetypeDropOnlyKnacks'));
                 return;
             }
 
@@ -719,7 +719,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         // Tome: store UUID references to dropped spells (no embedding)
         if (this.document.type === 'tome' && data?.type === 'Item') {
             if (!(game.user?.isGM ?? false)) {
-                ui.notifications.warn('Only the GM can add or remove spells from a Tome.');
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeDropModifyGmOnly'));
                 return;
             }
 
@@ -752,13 +752,13 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
             }
 
             if (!dropped || dropped.type !== 'spell') {
-                ui.notifications.warn('Only Spell items can be dropped onto a Tome.');
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemTomeDropOnlySpells'));
                 return;
             }
 
             const current = (this.document.system?.spellUuids ?? []).filter(u => !!u);
             if (current.includes(dropped.uuid)) {
-                ui.notifications.info('That spell is already in this Tome.');
+                ui.notifications.info(game.i18n.localize('ARKHAM_HORROR.Info.TomeSpellAlreadyInTome'));
                 return;
             }
 
@@ -798,13 +798,13 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
             }
 
             if (!dropped || dropped.type !== 'spell') {
-                ui.notifications.warn('Only Spell items can be dropped onto a Knack grant list.');
+                ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.ItemKnackDropOnlySpells'));
                 return;
             }
 
             const current = (this.document.system?.grants ?? []).filter(g => g?.type === 'spell' && g?.uuid);
             if (current.some(g => g.uuid === dropped.uuid)) {
-                ui.notifications.info('That spell is already granted by this Knack.');
+                ui.notifications.info(game.i18n.localize('ARKHAM_HORROR.Info.KnackSpellAlreadyGranted'));
                 return;
             }
 
@@ -846,7 +846,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
         if (this.document.type === 'tome') {
             const inaccessible = Number(context?.inaccessibleSpellCount ?? 0);
             if (inaccessible > 0 && !(game.user?.isGM ?? false) && !this.#tomeInaccessibleWarned) {
-                ui.notifications.warn(`This Tome contains ${inaccessible} spell(s) you do not have permission to view.`);
+                ui.notifications.warn(game.i18n.format('ARKHAM_HORROR.Warnings.ItemTomeInaccessibleSpells', { count: inaccessible }));
                 this.#tomeInaccessibleWarned = true;
             }
         }

--- a/module/sheets/npc-sheet.mjs
+++ b/module/sheets/npc-sheet.mjs
@@ -259,7 +259,7 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         if (!actor) return;
 
         const itemData = {
-            name: 'New Knack',
+            name: game.i18n.localize('ARKHAM_HORROR.NPC.NewKnack'),
             type: 'knack',
             system: {
                 isNPCknack: true,
@@ -281,7 +281,7 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         if (!actor) return;
 
         const itemData = {
-            name: 'New Weakness',
+            name: game.i18n.localize('ARKHAM_HORROR.NPC.NewWeakness'),
             type: 'knack',
             system: {
                 isNPCknack: true,
@@ -303,7 +303,7 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         if (!actor) return;
 
         const itemData = {
-            name: 'New Equipment',
+            name: game.i18n.localize('ARKHAM_HORROR.NPC.NewEquipment'),
             type: 'useful_item',
             system: {
                 hasSpecialRules: false,
@@ -326,7 +326,9 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         // Grab any data associated with this control.
         const data = duplicate(target.dataset);
         // Initialize a default name.
-        const name = `New ${type.capitalize()}`;
+        const name = game.i18n.format('DOCUMENT.New', {
+            type: game.i18n.localize(`TYPES.Item.${type}`)
+        });
         // Prepare the item object.
 
         const itemData = {
@@ -418,24 +420,32 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
     }
 
     static async #handleClickedRefreshDicePool(event, target) {
-        await refreshDicepoolAndPost({ actor: this.actor, label: "Dicepool Refresh", healDamage: false });
+        await refreshDicepoolAndPost({
+            actor: this.actor,
+            label: game.i18n.localize("ARKHAM_HORROR.DICEPOOL.Chat.Refresh"),
+            healDamage: false,
+        });
     }
 
     static async #handleClickedStrainOneself(event, target) {
         event.preventDefault();
 
         if (!this.actor?.isOwner) {
-            ui.notifications.warn('You do not have permission to strain for this Actor.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.PermissionStrainActor'));
             return;
         }
 
         const currentDamage = Number(this.actor.system?.damage ?? 0);
         if (currentDamage <= 0) {
-            ui.notifications.warn('You can only strain when your dice pool maximum is reduced by damage.');
+            ui.notifications.warn(game.i18n.localize('ARKHAM_HORROR.Warnings.StrainRequiresDamage'));
             return;
         }
 
-        await refreshDicepoolAndPost({ actor: this.actor, label: "Strain Oneself", healDamage: true });
+        await refreshDicepoolAndPost({
+            actor: this.actor,
+            label: game.i18n.localize("ARKHAM_HORROR.ACTIONS.StrainOneself"),
+            healDamage: true,
+        });
 
         InjuryTraumaRollApp.getInstance({
             actor: this.actor,

--- a/module/sheets/vehicle-sheet.mjs
+++ b/module/sheets/vehicle-sheet.mjs
@@ -187,7 +187,9 @@ export class ArkhamHorrorVehicleSheet extends HandlebarsApplicationMixin(ActorSh
         // Grab any data associated with this control.
         const data = duplicate(target.dataset);
         // Initialize a default name.
-        const name = `New ${type.capitalize()}`;
+        const name = game.i18n.format('DOCUMENT.New', {
+            type: game.i18n.localize(`TYPES.Item.${type}`)
+        });
         // Prepare the item object.
 
         const itemData = {

--- a/module/util/configuration.mjs
+++ b/module/util/configuration.mjs
@@ -1,7 +1,7 @@
 export function setupConfiguration() {
     game.settings.register("arkham-horror-rpg-fvtt", "tokenShowDicePools", {
-        name: "Show Token Dice Pools",
-        hint: "Show Dice Pool on tokens on the canvas.",
+        name: "ARKHAM_HORROR.Settings.TokenShowDicePools.Name",
+        hint: "ARKHAM_HORROR.Settings.TokenShowDicePools.Hint",
         scope: "world",
         config: true,
         type: Boolean,
@@ -9,8 +9,8 @@ export function setupConfiguration() {
     });
 
     game.settings.register("arkham-horror-rpg-fvtt", "tokenShowDamage", {
-        name: "Show Token Damage",
-        hint: "Show Damage on tokens on the canvas.",
+        name: "ARKHAM_HORROR.Settings.TokenShowDamage.Name",
+        hint: "ARKHAM_HORROR.Settings.TokenShowDamage.Hint",
         scope: "world",
         config: true,
         type: Boolean,
@@ -18,8 +18,8 @@ export function setupConfiguration() {
     });
 
     game.settings.register("arkham-horror-rpg-fvtt", "tokenOverlayAbove", {
-        name: "Token Overlay Above Token",
-        hint: "If enabled, show Dice Pool/Damage above the token instead of below.",
+        name: "ARKHAM_HORROR.Settings.TokenOverlayAbove.Name",
+        hint: "ARKHAM_HORROR.Settings.TokenOverlayAbove.Hint",
         scope: "world",
         config: true,
         type: Boolean,
@@ -27,8 +27,8 @@ export function setupConfiguration() {
     });
 
     game.settings.register("arkham-horror-rpg-fvtt", "characterLoadCapacity", {
-        name: "Character Load Capacity",
-        hint: "Automatic Load Capacity calculation",
+        name: "ARKHAM_HORROR.Settings.CharacterLoadCapacity.Name",
+        hint: "ARKHAM_HORROR.Settings.CharacterLoadCapacity.Hint",
         scope: "world",
         config: true,
         type: Boolean,
@@ -36,8 +36,8 @@ export function setupConfiguration() {
     });
 
     game.settings.register("arkham-horror-rpg-fvtt", "characterInjuryTable", {
-        name: "Character Injury Table",
-        hint: "Used for rolling injuries",
+        name: "ARKHAM_HORROR.Settings.CharacterInjuryTable.Name",
+        hint: "ARKHAM_HORROR.Settings.CharacterInjuryTable.Hint",
         scope: "world",
         config: true,
         type: String,
@@ -53,21 +53,21 @@ export function setupConfiguration() {
     });
     
     game.settings.register("arkham-horror-rpg-fvtt", "characterTraumaTableVariant", {
-        name: "Character Trauma Table Variant",
-        hint: "Choose which character trauma table to use when rolling trauma.",
+        name: "ARKHAM_HORROR.Settings.CharacterTraumaTableVariant.Name",
+        hint: "ARKHAM_HORROR.Settings.CharacterTraumaTableVariant.Hint",
         scope: "world",
         config: true,
         type: String,
         choices: {
-            standard: "Standard",
-            noPersonality: "No-Personality",
+            standard: "ARKHAM_HORROR.Settings.CharacterTraumaTableVariant.Choices.Standard",
+            noPersonality: "ARKHAM_HORROR.Settings.CharacterTraumaTableVariant.Choices.NoPersonality",
         },
         default: "standard"
     });
     
     game.settings.register("arkham-horror-rpg-fvtt", "characterHorrorTable", {
-        name: "Character Trauma Table",
-        hint: "Used for rolling trauma",
+        name: "ARKHAM_HORROR.Settings.CharacterTraumaTable.Name",
+        hint: "ARKHAM_HORROR.Settings.CharacterTraumaTable.Hint",
         scope: "world",
         config: true,
         type: String,
@@ -85,8 +85,8 @@ export function setupConfiguration() {
 
 
     game.settings.register("arkham-horror-rpg-fvtt", "characterHorrorTableNoPersonality", {
-        name: "Character Trauma Table (No-Personality)",
-        hint: "Optional alternate trauma table with fewer entries (no personality trait effects).",
+        name: "ARKHAM_HORROR.Settings.CharacterTraumaTableNoPersonality.Name",
+        hint: "ARKHAM_HORROR.Settings.CharacterTraumaTableNoPersonality.Hint",
         scope: "world",
         config: true,
         type: String,
@@ -102,8 +102,8 @@ export function setupConfiguration() {
     });
 
     game.settings.register("arkham-horror-rpg-fvtt", "npcInjuryTable", {
-        name: "NPC Injury Table",
-        hint: "Used for rolling injuries",
+        name: "ARKHAM_HORROR.Settings.NpcInjuryTable.Name",
+        hint: "ARKHAM_HORROR.Settings.NpcInjuryTable.Hint",
         scope: "world",
         config: true,
         type: String,
@@ -118,8 +118,8 @@ export function setupConfiguration() {
         default: ""
     });
     game.settings.register("arkham-horror-rpg-fvtt", "npcHorrorTable", {
-        name: "NPC Trauma Table",
-        hint: "Used for rolling trauma",
+        name: "ARKHAM_HORROR.Settings.NpcTraumaTable.Name",
+        hint: "ARKHAM_HORROR.Settings.NpcTraumaTable.Hint",
         scope: "world",
         config: true,
         type: String,

--- a/templates/actor/parts/_skill.hbs
+++ b/templates/actor/parts/_skill.hbs
@@ -1,8 +1,8 @@
 <div class="grid grid-5col skill-row">
     <label class="grid-span-2 skill clickable" data-action="clickSkill" data-skill-key="{{skillKey}}">{{localize (concat "ARKHAM_HORROR.SKILL." skillKey)}}</label>
-    <input type="number" name="system.skills.{{skillKey}}.current" value="{{skillData.current}}" data-dtype="Number" title="Limit" class="fancy-input">
-    <input type="number" name="system.skills.{{skillKey}}.max" value="{{skillData.max}}" data-dtype="Number" title="Max" class="fancy-input">
-    <span class="skill-reaction-icon clickable" data-action="clickSkillReaction" data-skill-key="{{skillKey}}" title="Reaction roll">
+    <input type="number" name="system.skills.{{skillKey}}.current" value="{{skillData.current}}" data-dtype="Number" title="{{localize "ARKHAM_HORROR.LABELS.Limit"}}" class="fancy-input">
+    <input type="number" name="system.skills.{{skillKey}}.max" value="{{skillData.max}}" data-dtype="Number" title="{{localize "ARKHAM_HORROR.LABELS.Max"}}" class="fancy-input">
+    <span class="skill-reaction-icon clickable" data-action="clickSkillReaction" data-skill-key="{{skillKey}}" title="{{localize "ARKHAM_HORROR.Chat.RollResult.ReactionRollTooltip"}}">
         <i class="fa-solid fa-arrow-rotate-left"></i>
     </span>
 </div>

--- a/templates/actor/parts/actor-effects.hbs
+++ b/templates/actor/parts/actor-effects.hbs
@@ -5,8 +5,8 @@
       <div class="effect-source">{{localize "ARKHAM_HORROR.Effect.Source"}}</div>
       <div class="effect-source">{{localize "EFFECT.TabDuration"}}</div>
       <div class="item-controls effect-controls flexrow">
-        <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type="Effect"}}">
-          <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type="Effect"}}
+        <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type=(localize 'DOCUMENT.ActiveEffect')}}">
+          <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type=(localize "DOCUMENT.ActiveEffect")}}
         </a>
       </div>
     </li>
@@ -24,10 +24,10 @@
           <a class="effect-control" data-action="toggle" title="{{localize 'ARKHAM_HORROR.Effect.Toggle'}}">
             <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
           </a>
-          <a class="effect-control" data-action="edit" title="{{localize 'DOCUMENT.Update' type="Effect"}}">
+          <a class="effect-control" data-action="edit" title="{{localize 'DOCUMENT.Update' type=(localize 'DOCUMENT.ActiveEffect')}}">
             <i class="fas fa-edit"></i>
           </a>
-          <a class="effect-control" data-action="delete" title="{{localize 'DOCUMENT.Delete' type="Effect"}}">
+          <a class="effect-control" data-action="delete" title="{{localize 'DOCUMENT.Delete' type=(localize 'DOCUMENT.ActiveEffect')}}">
             <i class="fas fa-trash"></i>
           </a>
         </div>

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -1,14 +1,14 @@
 <ol class='items-list'>
   <li class='item flexrow items-header'>
-    <div class='item-name'>{{localize 'Name'}}</div>
+    <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
     <div class='item-controls'>
       <a
         class='item-control item-create'
-        title='Create item'
+        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.feature")}}'
         data-type='feature'
       >
         <i class='fas fa-plus'></i>
-        {{localize 'DOCUMENT.New' type='feature'}}
+        {{localize "DOCUMENT.New" type=(localize "TYPES.Item.feature")}}
       </a>
     </div>
   </li>
@@ -30,13 +30,13 @@
       <div class='item-controls'>
         <a
           class='item-control item-edit'
-          title='{{localize "DOCUMENT.Edit" type='feature'}}'
+          title='{{localize "DOCUMENT.Edit" type=(localize "TYPES.Item.feature")}}'
         >
           <i class='fas fa-edit'></i>
         </a>
         <a
           class='item-control item-delete'
-          title='{{localize "DOCUMENT.Delete" type='feature'}}'
+          title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.feature")}}'
         >
           <i class='fas fa-trash'></i>
         </a>

--- a/templates/actor/parts/actor-items.hbs
+++ b/templates/actor/parts/actor-items.hbs
@@ -1,15 +1,15 @@
 <ol class='items-list'>
   <li class='item flexrow items-header'>
-    <div class='item-name'>{{localize 'Name'}}</div>
-    <div class='item-formula'>{{localize 'Roll Formula'}}</div>
+    <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
+    <div class='item-formula'>{{localize "ARKHAM_HORROR.PROPS.RollFormula"}}</div>
     <div class='item-controls'>
       <a
         class='item-control item-create'
-        title='{{localize "DOCUMENT.Create" type='Item'}}'
+        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.item")}}'
         data-type='item'
       >
         <i class='fas fa-plus'></i>
-        {{localize 'DOCUMENT.New' type='item'}}
+        {{localize "DOCUMENT.New" type=(localize "TYPES.Item.item")}}
       </a>
     </div>
   </li>
@@ -32,13 +32,13 @@
       <div class='item-controls'>
         <a
           class='item-control item-edit'
-          title='{{localize "DOCUMENT.Update" type='Item'}}'
+          title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.item")}}'
         >
           <i class='fas fa-edit'></i>
         </a>
         <a
           class='item-control item-delete'
-          title='{{localize "DOCUMENT.Delete" type='Item'}}'
+          title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.item")}}'
         >
           <i class='fas fa-trash'></i>
         </a>

--- a/templates/actor/parts/actor-spells.hbs
+++ b/templates/actor/parts/actor-spells.hbs
@@ -7,7 +7,7 @@
       <div class='item-controls'>
         <a
           class='item-control item-create'
-          title='{{localize "DOCUMENT.Create" type='Spell'}}'
+          title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.spell")}}'
           data-type='spell'
           data-spell-level='{{spellLevel}}'
         >
@@ -30,7 +30,7 @@
           <h4>{{item.name}}
             {{#with (lookup item.flags "arkham-horror-rpg-fvtt") as |ah|}}
               {{#if ah.tomeSourceName}}
-                <small class="notes">(Tome: {{ah.tomeSourceName}})</small>
+                <small class="notes">({{localize "ARKHAM_HORROR.LABELS.Tome"}}: {{ah.tomeSourceName}})</small>
               {{/if}}
             {{/with}}
           </h4>
@@ -38,13 +38,13 @@
         <div class='item-controls'>
           <a
             class='item-control item-edit'
-            title='{{localize "DOCUMENT.Edit" type='spell'}}'
+            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.spell")}}'
           >
             <i class='fas fa-edit'></i>
           </a>
           <a
             class='item-control item-delete'
-            title='{{localize "DOCUMENT.Delete" type='spell'}}'
+            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.spell")}}'
           >
             <i class='fas fa-trash'></i>
           </a>

--- a/templates/actor/parts/character-background.hbs
+++ b/templates/actor/parts/character-background.hbs
@@ -1,24 +1,24 @@
 <section class="tab {{tabs.background.id}} {{tabs.background.cssClass}} scrollable" id="background" data-tab="{{tabs.background.id}}" data-group="{{tabs.background.group}}">
     <div class="resource-group-styled">
 <div class="form-group">
-    <label for="placeOfOrigin">Place of Origin</label>
+    <label for="placeOfOrigin">{{localize "ARKHAM_HORROR.BACKGROUND.PlaceOfOrigin"}}</label>
     <input type="text" name="system.background.placeOfOrigin" id="placeOfOrigin" value="{{system.background.placeOfOrigin}}">
 </div>
 <div class="form-group">
-    <label for="familyAndFriends">Family and Friends</label>
+    <label for="familyAndFriends">{{localize "ARKHAM_HORROR.BACKGROUND.FamilyAndFriends"}}</label>
     <input type="text" name="system.background.familyAndFriends" id="familyAndFriends" value="{{system.background.familyAndFriends}}">
 </div>
 <div class="form-group">
-    <label for="employment">Employment</label>
+    <label for="employment">{{localize "ARKHAM_HORROR.BACKGROUND.Employment"}}</label>
     <input type="text" name="system.background.employment" id="employment" value="{{system.background.employment}}">
 </div>
 <div class="form-group">
-    <label for="weeklySalary">Weekly Salary</label>
+    <label for="weeklySalary">{{localize "ARKHAM_HORROR.BACKGROUND.WeeklySalary"}}</label>
     <input type="number" name="system.background.weeklySalary" id="weeklySalary" value="{{system.background.weeklySalary}}" data-dtype="Number">
 </div>
 </div>
 <div class="form-group-editor mt-10">
-    <h5>Biography</h5>
+    <h5>{{localize "ARKHAM_HORROR.BACKGROUND.Biography"}}</h5>
     <prose-mirror name="system.biography" button="true" editable="{{editable}}" toggled="false"
             value="{{system.biography}}">
             {{{biographyHTML}}}
@@ -26,14 +26,14 @@
 </div>
 
 <div class="form-group-editor mt-10">
-    <h5>First Supernatural Encounter</h5>
+    <h5>{{localize "ARKHAM_HORROR.BACKGROUND.FirstSupernaturalEncounter"}}</h5>
     <prose-mirror name="system.background.firstSupernaturalEncounter" button="true" editable="{{editable}}" toggled="false"
             value="{{system.background.firstSupernaturalEncounter}}">
             {{{firstSupernaturalEncounterHTML}}}
         </prose-mirror>
 </div>
 <div class="form-group-editor mt-10">
-    <h5>Notable Enemies</h5>
+    <h5>{{localize "ARKHAM_HORROR.BACKGROUND.NotableEnemies"}}</h5>
     <prose-mirror name="system.background.notableEnemies" button="true" editable="{{editable}}" toggled="false"
             value="{{system.background.notableEnemies}}">
             {{{notableEnemiesHTML}}}

--- a/templates/actor/parts/character-header.hbs
+++ b/templates/actor/parts/character-header.hbs
@@ -6,18 +6,18 @@
         {{!-- Edit Mode Layout --}}
         <div class="title">
             <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" class="fancy-input"
-                    placeholder="{{localize 'MIST_ENGINE.PLACEHOLDERS.Name'}}" /></h1>
+                    placeholder="{{localize "ARKHAM_HORROR.PROPS.Name"}}" /></h1>
 
         </div>
         <div class="resource-group-styled other">
             <div class="archetype-entry">
-                <label for="system.archetype" class="styled-label">ARCHETYPE</label>
+                <label for="system.archetype" class="styled-label">{{localize "ARKHAM_HORROR.LABELS.Archetype"}}</label>
                 {{#if system.archetypeUuid}}
                 <div class="form-fields" style="display:flex; gap:6px; align-items:center;">
                     <input type="text" name="system.archetype" value="{{system.archetype}}" readonly
-                        data-action="openActorArchetype" title="Open Archetype" style="flex:1; cursor:pointer;"
+                        data-action="openActorArchetype" title="{{localize "ARKHAM_HORROR.TOOLTIPS.OpenArchetype"}}" style="flex:1; cursor:pointer;"
                         class="fancy-input" />
-                    <a class="item-control" data-action="openActorArchetype" title="Open Archetype">
+                    <a class="item-control" data-action="openActorArchetype" title="{{localize "ARKHAM_HORROR.TOOLTIPS.OpenArchetype"}}" aria-label="{{localize "ARKHAM_HORROR.TOOLTIPS.OpenArchetype"}}">
                         <i class="fas fa-up-right-from-square"></i>
                     </a>
                 </div>
@@ -28,12 +28,12 @@
             <div class="xp">
                 <div class="grid grid-4col">
                     <div class="header-form-group">
-                        <label for="system.xp.total" class="styled-label">XP:</label>
+                        <label for="system.xp.total" class="styled-label">{{localize "ARKHAM_HORROR.PROPS.XP"}}:</label>
                         <input type="number" name="system.xp.unused" value="{{system.xp.unused}}" data-dtype="Number"
-                            class="medium-input fancy-input" title="Unused XP" />
-                        of
+                            class="medium-input fancy-input" title="{{localize "ARKHAM_HORROR.TOOLTIPS.UnusedXP"}}" />
+                        {{localize "ARKHAM_HORROR.WORDS.Of"}}
                         <input type="number" name="system.xp.total" value="{{system.xp.total}}" data-dtype="Number"
-                            class="medium-input fancy-input" title="Total XP" />
+                            class="medium-input fancy-input" title="{{localize "ARKHAM_HORROR.TOOLTIPS.TotalXP"}}" />
                     </div>
                     <div class="header-form-group">
                         <label for="system.dicepool.max" class="header-label">{{localize "ARKHAM_HORROR.LABELS.Dicepool" }}:</label>

--- a/templates/actor/parts/character-injuries.hbs
+++ b/templates/actor/parts/character-injuries.hbs
@@ -1,7 +1,7 @@
 <fieldset>
     <legend>
         {{localize "ARKHAM_HORROR.LABELS.InjuriesTrauma"}}
-        <a class='item-control' data-action="clickedInjuryTraumaRoll" title="Roll Injury/Trauma">
+        <a class='item-control' data-action="clickedInjuryTraumaRoll" title="{{localize "ARKHAM_HORROR.ACTIONS.RollInjuryTrauma"}}" aria-label="{{localize "ARKHAM_HORROR.ACTIONS.RollInjuryTrauma"}}">
             <i class="fa-solid fa-dice"></i>
         </a>
     </legend>
@@ -9,15 +9,13 @@
     <div class="injury-entry">
         <div>
             <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="injury{{injury._id}}">
-                {{#if (eq injury.type 'trauma')}}[TRAUMA] {{/if}}
-                {{#if (eq injury.type 'injury')}}[INJURY] {{/if}}
+                {{#if (eq injury.type 'trauma')}}[{{localize "TYPES.Item.trauma"}}] {{/if}}
+                {{#if (eq injury.type 'injury')}}[{{localize "TYPES.Item.injury"}}] {{/if}}
                 {{injury.name}}</strong>
-            <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type='
-                injury'}}' data-item-id='{{injury._id}}'>
+            <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type=(localize (concat "TYPES.Item." injury.type))}}' aria-label='{{localize "DOCUMENT.Update" type=(localize (concat "TYPES.Item." injury.type))}}' data-item-id='{{injury._id}}'>
                 <i class='fas fa-edit'></i>
             </a>
-            <a class='item-control item-delete' data-action="deleteItem" title='{{localize "DOCUMENT.Delete" type='
-                injury'}}' data-item-id='{{injury._id}}'>
+            <a class='item-control item-delete' data-action="deleteItem" title='{{localize "DOCUMENT.Delete" type=(localize (concat "TYPES.Item." injury.type))}}' aria-label='{{localize "DOCUMENT.Delete" type=(localize (concat "TYPES.Item." injury.type))}}' data-item-id='{{injury._id}}'>
                 <i class='fas fa-trash'></i>
             </a>
         </div>

--- a/templates/actor/parts/character-knacks.hbs
+++ b/templates/actor/parts/character-knacks.hbs
@@ -1,34 +1,32 @@
 <fieldset>
-    <legend>KNACKS
-        <a class='item-control' data-action="resetAllKnackUses" title='Reset Knack Uses'>
+    <legend>{{localize "ARKHAM_HORROR.LABELS.Knacks"}}
+        <a class='item-control' data-action="resetAllKnackUses" title='{{localize "ARKHAM_HORROR.ACTIONS.ResetAllKnackUses"}}' aria-label='{{localize "ARKHAM_HORROR.ACTIONS.ResetAllKnackUses"}}'>
             <i class='fas fa-rotate-right'></i>
         </a>
         <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='knack'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.knack")}}' aria-label='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.knack")}}' data-type='knack'>
                         <i class='fas fa-plus'></i>
                     </a></legend>
     {{#each knacks as |knack|}}
     <div class="knack-entry">
         <div>
             <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="knack{{knack._id}}">
-                Tier {{knack.system.tier}} - {{knack.name}}
+                {{localize "ARKHAM_HORROR.Dialog.DiceRoll.Tier" tier=knack.system.tier}} - {{knack.name}}
                 {{#if knack.system.usage}}
-                    <small class="notes">({{knack.system.usage.frequency}}
+                    <small class="notes">({{localize (concat "ARKHAM_HORROR.KNACK_USAGE." knack.system.usage.frequency)}}
                         {{#if (eq knack.system.usage.frequency "oncePerTurn")}}: {{knack.system.usage.remaining}}/{{knack.system.usage.max}}{{/if}}
                         {{#if (eq knack.system.usage.frequency "oncePerScene")}}: {{knack.system.usage.remaining}}/{{knack.system.usage.max}}{{/if}}
                         {{#if (eq knack.system.usage.frequency "oncePerSession")}}: {{knack.system.usage.remaining}}/{{knack.system.usage.max}}{{/if}}
                     )</small>
                 {{/if}}
             </strong>
-            <a class='item-control' data-action="resetKnackUses" title='Reset This Knack' data-item-id='{{knack._id}}'>
+            <a class='item-control' data-action="resetKnackUses" title='{{localize "ARKHAM_HORROR.ACTIONS.ResetKnackUses"}}' aria-label='{{localize "ARKHAM_HORROR.ACTIONS.ResetKnackUses"}}' data-item-id='{{knack._id}}'>
                 <i class='fas fa-rotate-right'></i>
             </a>
-            <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type='
-                knack'}}' data-item-id='{{knack._id}}'>
+            <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.knack")}}' aria-label='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.knack")}}' data-item-id='{{knack._id}}'>
                 <i class='fas fa-edit'></i>
             </a>
-            <a class='item-control item-delete' data-action="deleteItem" title='{{localize "DOCUMENT.Delete" type='
-                knack'}}' data-item-id='{{knack._id}}'>
+            <a class='item-control item-delete' data-action="deleteItem" title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.knack")}}' aria-label='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.knack")}}' data-item-id='{{knack._id}}'>
                 <i class='fas fa-trash'></i>
             </a>
         </div>

--- a/templates/actor/parts/character-mundane-resources.hbs
+++ b/templates/actor/parts/character-mundane-resources.hbs
@@ -5,14 +5,14 @@
             <div class="form-group">
                 <label for="money">{{localize "ARKHAM_HORROR.LABELS.Money"}}</label>
                 <div class="flexrow money-controls-row">
-                    <a class="clickable money-action" data-action="adjustMoney" data-mode="add" title="{{localize 'ARKHAM_HORROR.MONEY.Tooltips.Add'}}" aria-label="{{localize 'ARKHAM_HORROR.MONEY.Tooltips.Add'}}">
+                    <a class="clickable money-action" data-action="adjustMoney" data-mode="add" title="{{localize "ARKHAM_HORROR.MONEY.Tooltips.Add"}}" aria-label="{{localize "ARKHAM_HORROR.MONEY.Tooltips.Add"}}">
                         <i class="fa-solid fa-plus"></i>
                     </a>
                     <span class="fancy-input money-display" id="money">{{moneyDisplay}}</span>
-                    <a class="clickable money-action" data-action="adjustMoney" data-mode="spend" title="{{localize 'ARKHAM_HORROR.MONEY.Tooltips.Spend'}}" aria-label="{{localize 'ARKHAM_HORROR.MONEY.Tooltips.Spend'}}">
+                    <a class="clickable money-action" data-action="adjustMoney" data-mode="spend" title="{{localize "ARKHAM_HORROR.MONEY.Tooltips.Spend"}}" aria-label="{{localize "ARKHAM_HORROR.MONEY.Tooltips.Spend"}}">
                         <i class="fa-solid fa-minus"></i>
                     </a>
-                    <a class="clickable money-action" data-action="adjustMoney" data-mode="set" title="{{localize 'ARKHAM_HORROR.MONEY.Tooltips.Set'}}" aria-label="{{localize 'ARKHAM_HORROR.MONEY.Tooltips.Set'}}">
+                    <a class="clickable money-action" data-action="adjustMoney" data-mode="set" title="{{localize "ARKHAM_HORROR.MONEY.Tooltips.Set"}}" aria-label="{{localize "ARKHAM_HORROR.MONEY.Tooltips.Set"}}">
                         <i class="fa-solid fa-pen"></i>
                     </a>
                 </div>
@@ -43,7 +43,7 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.Weapons"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Skill"}}</div>
                 <div class='item-prop damage-prop' title="{{localize "ARKHAM_HORROR.PROPS.Damage"}}">{{localize "ARKHAM_HORROR.PROPS.DamageShort"}}</div>
                 <div class='item-prop injury-rating-prop' title="{{localize "ARKHAM_HORROR.PROPS.InjuryRating"}}">{{localize "ARKHAM_HORROR.PROPS.InjuryRatingShort"}}</div>
@@ -51,7 +51,7 @@
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Ammunition"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='weapon'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.weapon")}}' data-type='weapon'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -63,7 +63,7 @@
                         data-fc-id="weapon{{item._id}}">
                         <div class='item-image'>
                             <a class='rollable' data-roll-type='item'>
-                                <img src='{{item.img}}' title='{{item.name}} - click to expand special rules' width='24'
+                                <img src='{{item.img}}' title='{{localize "ARKHAM_HORROR.TOOLTIPS.ExpandSpecialRules" itemName=item.name}}' width='24'
                                     height='24' />
                             </a>
                         </div>
@@ -73,20 +73,20 @@
                     <div class='item-prop damage-prop'>{{item.system.damage}}</div>
                     <div class='item-prop injury-rating-prop'>{{item.system.injuryRating}}</div>
                     <div class='item-prop range-prop'>
-                        {{#if (eq item.system.range 0)}}Engaged{{else}}{{item.system.range}}{{/if}}
+                        {{#if (eq item.system.range 0)}}{{localize "ARKHAM_HORROR.PROPS.Engaged"}}{{else}}{{item.system.range}}{{/if}}
                     </div>
                     <div class='item-prop'><input type="text" value="{{item.system.ammunition.current}}"
                             data-item-stat="system.ammunition.current" class="item-editable-stat ammo_input"> /
                         {{item.system.ammunition.max}} <span class="weapon-reload-icon" data-item-id='{{item._id}}'
-                            data-action="clickWeaponReload" title="{reload"><i
+                            data-action="clickWeaponReload" title="{{localize "ARKHAM_HORROR.ACTIONS.Reload"}}" aria-label="{{localize "ARKHAM_HORROR.ACTIONS.Reload"}}"><i
                                 class="fa-solid fa-rotate clickable"></i></span></div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.weapon")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.weapon")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -107,11 +107,11 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.ProtectiveEquipment"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='protective_equipment'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.protective_equipment")}}' data-type='protective_equipment'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -131,11 +131,11 @@
                     <div class='item-prop'>{{formatCurrency item.system.cost}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.protective_equipment")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.protective_equipment")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -162,12 +162,12 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.UsefulItems"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Uses"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Useful Item'}}' data-type='useful_item'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.useful_item")}}' data-type='useful_item'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -190,11 +190,11 @@
                         {{item.system.uses.max}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -216,11 +216,11 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.OtherEquipment"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createOtherEquipment"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.item")}}'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -240,18 +240,18 @@
                     <div class='item-prop'>{{#if item.system.costs}}{{item.system.costs}}{{else}}{{formatCurrency item.system.cost}}{{/if}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.item")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.item")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
                 </div>
                 <div class="foldable-content" data-fc-id="otherEquipment{{item._id}}">
                     <div>
-                        <strong>Description:</strong>
+                        <strong>{{localize "ARKHAM_HORROR.LABELS.Description"}}:</strong>
                         {{{item.system.description}}}
                     </div>
                 </div>
@@ -264,11 +264,11 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.Favors"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
-                <div class='item-prop'>XP</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
+                <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.XP"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Favor'}}' data-type='favor'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.favor")}}' data-type='favor'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -288,11 +288,11 @@
                     <div class='item-prop'>{{item.system.xp}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.favor")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.favor")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -300,15 +300,15 @@
                 <div class="foldable-content" data-fc-id="usefulItem{{item._id}}">
                     <div class="grid grid-3col">
                         <div>
-                            <strong>Benefit</strong>
+                            <strong>{{localize "ARKHAM_HORROR.PROPS.Benefit"}}</strong>
                             {{{item.system.benefit}}}
                         </div>
                         <div>
-                            <strong>Declining</strong>
+                            <strong>{{localize "ARKHAM_HORROR.PROPS.Declining"}}</strong>
                             {{{item.system.decliningText}}}
                         </div>
                         <div>
-                            <strong>Losing</strong>
+                            <strong>{{localize "ARKHAM_HORROR.PROPS.Losing"}}</strong>
                             {{{item.system.losingText}}}
                         </div>
                     </div>

--- a/templates/actor/parts/character-personality-trait.hbs
+++ b/templates/actor/parts/character-personality-trait.hbs
@@ -6,10 +6,10 @@
             <div class="foldable-content" data-fc-id="personalityTrait{{personalityTrait._id}}">
             <p>{{{personalityTrait.system.description}}}</p>
             </div>
-            <p><strong>Positive:</strong> {{personalityTrait.system.positive}}</p>
-            <p><strong>Negative:</strong> {{personalityTrait.system.negative}}</p>
+            <p><strong>{{localize "ARKHAM_HORROR.PERSONALITY.Positive"}}:</strong> {{personalityTrait.system.positive}}</p>
+            <p><strong>{{localize "ARKHAM_HORROR.PERSONALITY.Negative"}}:</strong> {{personalityTrait.system.negative}}</p>
         </div>
     {{else}}
-        <p>No personality trait assigned. Drag'N'Drop one here.</p>
+        <p>{{localize "ARKHAM_HORROR.PERSONALITY.NoneAssigned"}}</p>
     {{/if}}
 </fieldset>

--- a/templates/actor/parts/character-supernatural-resources.hbs
+++ b/templates/actor/parts/character-supernatural-resources.hbs
@@ -6,13 +6,13 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.Spells"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Skill"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Difficulty"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Range"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' spell'}}' data-type='spell'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.spell")}}' data-type='spell'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -47,11 +47,11 @@
                     <div class='item-prop'>{{item.system.range}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type='Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type='Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -70,13 +70,13 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.Tomes"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ITEM.Tome.rarity"}}</div>
                 <div class='item-prop'>{{localize "ITEM.Tome.understood"}}</div>
                 <div class='item-prop'>{{localize "ITEM.Tome.attuned"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='tome'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.tome")}}' data-type='tome'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -94,16 +94,16 @@
                     </div>
                     <div class='item-prop'>
                         {{#if item.system.rarity.common}}
-                        Common
+                        {{localize "ARKHAM_HORROR.RARITY.common"}}
                         {{/if}}
                         {{#if item.system.rarity.rare}}
-                        Rare
+                        {{localize "ARKHAM_HORROR.RARITY.rare"}}
                         {{/if}}
                         {{#if item.system.rarity.unique}}
-                        Unique
+                        {{localize "ARKHAM_HORROR.RARITY.unique"}}
                         {{/if}}
                         {{#if item.system.rarity.uncommon}}
-                        Uncommon
+                        {{localize "ARKHAM_HORROR.RARITY.uncommon"}}
                         {{/if}}
                     </div>
                     <div class='item-prop'>
@@ -140,11 +140,11 @@
                     </div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type='Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.tome")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type='Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.tome")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -164,11 +164,11 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.Relics"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
-                <div class='item-prop'>Rarity</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
+                <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Rarity"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='relic'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.relic")}}' data-type='relic'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -186,25 +186,25 @@
                     </div>
                     <div class='item-prop'>
                         {{#if item.system.rarity.common}}
-                        Common
+                        {{localize "ARKHAM_HORROR.RARITY.common"}}
                         {{/if}}
                         {{#if item.system.rarity.rare}}
-                        Rare
+                        {{localize "ARKHAM_HORROR.RARITY.rare"}}
                         {{/if}}
                         {{#if item.system.rarity.unique}}
-                        Unique
+                        {{localize "ARKHAM_HORROR.RARITY.unique"}}
                         {{/if}}
                         {{#if item.system.rarity.uncommon}}
-                        Uncommon
+                        {{localize "ARKHAM_HORROR.RARITY.uncommon"}}
                         {{/if}}
                     </div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' relic'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.relic")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' relic'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.relic")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>

--- a/templates/chat/dicepool-reset.hbs
+++ b/templates/chat/dicepool-reset.hbs
@@ -1,6 +1,6 @@
 <div>
-    <strong>{{label}}</strong>: {{actorName}}'s dice pool changed from {{oldDicePoolValue}} to {{newDicePoolValue}}.
+    <strong>{{label}}</strong>: {{localize "ARKHAM_HORROR.Chat.DicepoolReset.Changed" actorName=actorName oldDicePoolValue=oldDicePoolValue newDicePoolValue=newDicePoolValue}}
     {{#if healedDamage}}
-        (Healed {{healedDamage}} damage)
+        ({{localize "ARKHAM_HORROR.Chat.DicepoolReset.HealedDamage" healedDamage=healedDamage}})
     {{/if}}
 </div>

--- a/templates/chat/injury-trauma-roll-card.hbs
+++ b/templates/chat/injury-trauma-roll-card.hbs
@@ -3,9 +3,9 @@
     <div class="arkham-roll-heading">
       <span class="arkham-roll-kind {{#if (eq rollKind "injury")}}is-injury{{else}}is-trauma{{/if}}">
         {{#if (eq rollMode "falling")}}
-          <i class="fa-solid fa-person-falling arkham-roll-reaction-icon" title="Falling" aria-hidden="true"></i>
+          <i class="fa-solid fa-person-falling arkham-roll-reaction-icon" title="{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.FallingTooltip"}}" aria-hidden="true"></i>
         {{else if (eq rollSource "strain")}}
-          <i class="fa-solid fa-hand-fist arkham-roll-reaction-icon" title="Strain Oneself" aria-hidden="true"></i>
+          <i class="fa-solid fa-hand-fist arkham-roll-reaction-icon" title="{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.StrainTooltip"}}" aria-hidden="true"></i>
         {{/if}}
         {{rollKindLabel}}
       </span>
@@ -27,13 +27,13 @@
 
   {{#if (eq rollSource "strain")}}
     <div class="arkham-injury-trauma-description">
-      <strong>Strain Oneself:</strong> apply the resulting injury at end of turn / after 1 complex action.
+      <strong>{{localize "ARKHAM_HORROR.ACTIONS.StrainOneself"}}:</strong> {{localize "ARKHAM_HORROR.Chat.InjuryTrauma.StrainNote"}}
     </div>
   {{/if}}
 
   {{#if (eq rollMode "falling")}}
     <div class="arkham-injury-trauma-description">
-      <strong>Falling Injury</strong> — Height: {{fallingHeightFt}} ft
+      <strong>{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.FallingLabel"}}</strong> — {{localize "ARKHAM_HORROR.Chat.InjuryTrauma.HeightLabel"}}: {{fallingHeightFt}} {{localize "ARKHAM_HORROR.UNITS.Ft"}}
     </div>
   {{/if}}
 
@@ -44,40 +44,40 @@
   {{/if}}
 
   <details class="arkham-roll-details">
-    <summary class="arkham-roll-details-summary">Roll Details</summary>
+    <summary class="arkham-roll-details-summary">{{localize "ARKHAM_HORROR.Chat.RollResult.RollDetails"}}</summary>
     <div class="arkham-roll-details-body">
       <div class="arkham-roll-meta">
         <div class="arkham-meta-row">
-          <span class="arkham-meta-label">Roll</span>
+          <span class="arkham-meta-label">{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.Roll"}}</span>
           <span class="arkham-meta-value">{{numDice}}d{{dieFaces}}</span>
         </div>
 
         {{#if (eq numDice 1)}}
           <div class="arkham-meta-row">
-            <span class="arkham-meta-label">Die</span>
+            <span class="arkham-meta-label">{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.Die"}}</span>
             <span class="arkham-meta-value">{{dieResult}}</span>
           </div>
         {{else}}
           <div class="arkham-meta-row">
-            <span class="arkham-meta-label">Dice</span>
+            <span class="arkham-meta-label">{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.Dice"}}</span>
             <span class="arkham-meta-value">{{dieResultsLabel}}</span>
           </div>
           <div class="arkham-meta-row">
-            <span class="arkham-meta-label">Die Total</span>
+            <span class="arkham-meta-label">{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.DieTotal"}}</span>
             <span class="arkham-meta-value">{{dieTotal}}</span>
           </div>
         {{/if}}
 
         <div class="arkham-meta-row">
-          <span class="arkham-meta-label">Modifier</span>
+          <span class="arkham-meta-label">{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.Modifier"}}</span>
           <span class="arkham-meta-value">{{#if modifierApplied}}{{modifier}}{{else}}—{{/if}}</span>
         </div>
         <div class="arkham-meta-row">
-          <span class="arkham-meta-label">Total</span>
+          <span class="arkham-meta-label">{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.Total"}}</span>
           <span class="arkham-meta-value">{{total}}</span>
         </div>
         <div class="arkham-meta-row">
-          <span class="arkham-meta-label">Table</span>
+          <span class="arkham-meta-label">{{localize "ARKHAM_HORROR.Chat.InjuryTrauma.Table"}}</span>
           <span class="arkham-meta-value">{{tableRange}}</span>
         </div>
       </div>

--- a/templates/chat/insight-update.hbs
+++ b/templates/chat/insight-update.hbs
@@ -1,7 +1,7 @@
 <div>
   {{#if (eq action "spend")}}
-    <strong>Insight Spent:</strong> {{actorName}} spent {{spent}} Insight ({{oldRemaining}} → {{newRemaining}}/{{limit}}).
+    <strong>{{localize "ARKHAM_HORROR.Chat.Insight.LabelSpent"}}:</strong> {{localize "ARKHAM_HORROR.Chat.Insight.Spent" actorName=actorName spent=spent oldRemaining=oldRemaining newRemaining=newRemaining limit=limit}}
   {{else}}
-    <strong>Insight Refreshed:</strong> {{actorName}}'s Insight has been refreshed from {{oldRemaining}} to {{newRemaining}}.
+    <strong>{{localize "ARKHAM_HORROR.Chat.Insight.LabelRefreshed"}}:</strong> {{localize "ARKHAM_HORROR.Chat.Insight.Refreshed" actorName=actorName oldRemaining=oldRemaining newRemaining=newRemaining}}
   {{/if}}
 </div>

--- a/templates/chat/roll-result.hbs
+++ b/templates/chat/roll-result.hbs
@@ -3,7 +3,7 @@
         <div class="arkham-roll-heading">
             <span class="arkham-roll-kind">
                 {{#if (eq rollKind "reaction")}}
-                    <i class="fa-solid fa-arrow-rotate-left arkham-roll-reaction-icon" title="Reaction roll"></i>
+                    <i class="fa-solid fa-arrow-rotate-left arkham-roll-reaction-icon" title="{{localize "ARKHAM_HORROR.Chat.RollResult.ReactionRollTooltip"}}"></i>
                 {{/if}}
                 {{#if (eq rollKind "tome-understand")}}
                     <i class="fa-solid fa-book-atlas arkham-roll-reaction-icon" title="{{rollKindLabel}}"></i>
@@ -15,28 +15,33 @@
             </span>
         </div>
         <div class="arkham-roll-subtitle">
-            <span class="arkham-roll-flag is-diff">{{#if (eq successesNeeded 1)}}Normal{{else if (eq successesNeeded 2)}}Difficult{{else if (eq successesNeeded 3)}}Very<br />Difficult{{else}}Difficulty {{successesNeeded}}{{/if}}</span>
+            <span class="arkham-roll-flag is-diff">
+                {{#if (eq successesNeeded 1)}}{{{localize "ARKHAM_HORROR.DIFFICULTY_CHAT.Normal"}}}
+                {{else if (eq successesNeeded 2)}}{{{localize "ARKHAM_HORROR.DIFFICULTY_CHAT.Difficult"}}}
+                {{else if (eq successesNeeded 3)}}{{{localize "ARKHAM_HORROR.DIFFICULTY_CHAT.VeryDifficult"}}}
+                {{else}}{{localize "ARKHAM_HORROR.PROPS.Difficulty"}} {{successesNeeded}}{{/if}}
+            </span>
         </div>
     </header>
 
     {{#if isReroll}}
         <div class="arkham-reroll-banner">
-            <span class="arkham-reroll-label">Reroll</span>
+            <span class="arkham-reroll-label">{{localize "ARKHAM_HORROR.Chat.RollResult.Reroll"}}</span>
         </div>
     {{/if}}
 
     <div class="arkham-roll-banner {{#if isSuccess}}is-success{{else}}is-failure{{/if}}">
         {{#if isSuccess}}
-            SUCCESS
+            {{localize "ARKHAM_HORROR.Chat.RollResult.Success"}}
         {{else}}
-            FAILURE
+            {{localize "ARKHAM_HORROR.Chat.RollResult.Failure"}}
         {{/if}}
     </div>
 
     <div class="arkham-roll-results">
         <div class="arkham-dice-results">
             <div class="arkham-dice-results-row">
-                <div class="dice-results-container arkham-dice-results-container"{{#if horrorDiceUsed}} title="Horror dice are marked in black."{{/if}}>
+                <div class="dice-results-container arkham-dice-results-container"{{#if horrorDiceUsed}} title="{{localize "ARKHAM_HORROR.Chat.RollResult.HorrorDiceTooltip"}}"{{/if}}>
                     {{#each results}}
                         {{#unless isDropped}}
                             <span class="dice-result arkham-die
@@ -48,7 +53,7 @@
                     {{/each}}
                 </div>
 
-                <button type="button" class="arkham-reroll-icon" data-action="arkham-reroll" title="Reroll dice" aria-label="Reroll dice">
+                <button type="button" class="arkham-reroll-icon" data-action="arkham-reroll" title="{{localize "ARKHAM_HORROR.Chat.RollResult.RerollDice"}}" aria-label="{{localize "ARKHAM_HORROR.Chat.RollResult.RerollDice"}}">
                     <i class="fa-solid fa-arrow-rotate-right" aria-hidden="true"></i>
                 </button>
             </div>
@@ -56,28 +61,28 @@
         
         {{#if showRollDetails}}
         <details class="arkham-roll-details">
-            <summary class="arkham-roll-details-summary">Roll Details</summary>
+            <summary class="arkham-roll-details-summary">{{localize "ARKHAM_HORROR.Chat.RollResult.RollDetails"}}</summary>
             <div class="arkham-roll-details-body">
                 <div class="arkham-roll-flags">
                     {{#if rollWithAdvantage}}
-                        <span class="arkham-roll-flag is-adv">Advantage</span>
+                        <span class="arkham-roll-flag is-adv">{{localize "ARKHAM_HORROR.Chat.RollResult.Advantage"}}</span>
                     {{/if}}
                     {{#if rollWithDisadvantage}}
-                        <span class="arkham-roll-flag is-dis">Disadvantage</span>
+                        <span class="arkham-roll-flag is-dis">{{localize "ARKHAM_HORROR.Chat.RollResult.Disadvantage"}}</span>
                     {{/if}}
                     {{#if (gte penalty 1)}}
-                        <span class="arkham-roll-flag is-diff">Penalty -{{penalty}}</span>
+                        <span class="arkham-roll-flag is-diff">{{localize "ARKHAM_HORROR.Chat.RollResult.Penalty" penalty=penalty}}</span>
                     {{/if}}
                     {{#if (gte resultModifier 1)}}
-                    <span class="arkham-roll-flag is-diff">Result +{{resultModifier}}</span>
+                    <span class="arkham-roll-flag is-diff">{{localize "ARKHAM_HORROR.Chat.RollResult.Result" resultModifier=resultModifier}}</span>
                     {{/if}}
                     {{#if (gte bonusDice 1)}}
-                    <span class="arkham-roll-flag is-diff">Bonus Dice: {{bonusDice}}</span>
+                    <span class="arkham-roll-flag is-diff">{{localize "ARKHAM_HORROR.Chat.RollResult.BonusDice" bonusDice=bonusDice}}</span>
                     {{/if}}
                 </div>
                 {{#if rollWithAdvantage}}
                     <div class="arkham-roll-details-row">
-                        <span class="arkham-roll-details-label">Dropped Dice</span>
+                        <span class="arkham-roll-details-label">{{localize "ARKHAM_HORROR.Chat.RollResult.DroppedDice"}}</span>
                         <span class="arkham-roll-details-value">
                             {{#each results}}
                                 {{#if isDropped}}
@@ -89,7 +94,7 @@
                 {{else}}
                     {{#if rollWithDisadvantage}}
                         <div class="arkham-roll-details-row">
-                            <span class="arkham-roll-details-label">Dropped Dice</span>
+                            <span class="arkham-roll-details-label">{{localize "ARKHAM_HORROR.Chat.RollResult.DroppedDice"}}</span>
                             <span class="arkham-roll-details-value">
                                 {{#each results}}
                                     {{#if isDropped}}
@@ -102,12 +107,12 @@
                 {{/if}}
                 {{#if (gte penalty 1)}}
                 <div class="arkham-roll-details-row">
-                    <span class="arkham-roll-details-label">Raw Dice Result</span>
+                    <span class="arkham-roll-details-label">{{localize "ARKHAM_HORROR.Chat.RollResult.RawDiceResult"}}</span>
                 </div>
                     <div class="arkham-roll-results">
                         <div class="arkham-dice-results">
                             <div class="arkham-dice-results-row">
-                                <div class="dice-results-container arkham-dice-results-container"{{#if horrorDiceUsed}} title="Horror dice are marked in black."{{/if}}>
+                                <div class="dice-results-container arkham-dice-results-container"{{#if horrorDiceUsed}} title="{{localize "ARKHAM_HORROR.Chat.RollResult.HorrorDiceTooltip"}}"{{/if}}>
                                     {{#each results}}
                                         {{#unless isDropped}}
                                             <span class="dice-result arkham-die
@@ -123,12 +128,12 @@
                     </div>
                 {{else if (gte resultModifier 1)}}
                 <div class="arkham-roll-details-row">
-                    <span class="arkham-roll-details-label">Raw Dice Result</span>
+                    <span class="arkham-roll-details-label">{{localize "ARKHAM_HORROR.Chat.RollResult.RawDiceResult"}}</span>
                 </div>
                     <div class="arkham-roll-results">
                         <div class="arkham-dice-results">
                             <div class="arkham-dice-results-row">
-                                <div class="dice-results-container arkham-dice-results-container"{{#if horrorDiceUsed}} title="Horror dice are marked in black."{{/if}}>
+                                <div class="dice-results-container arkham-dice-results-container"{{#if horrorDiceUsed}} title="{{localize "ARKHAM_HORROR.Chat.RollResult.HorrorDiceTooltip"}}"{{/if}}>
                                     {{#each results}}
                                         {{#unless isDropped}}
                                             <span class="dice-result arkham-die
@@ -149,15 +154,15 @@
 
         <div class="arkham-totals">
             <div class="arkham-total">
-                <span class="arkham-total-label">Successes</span>
+                <span class="arkham-total-label">{{localize "ARKHAM_HORROR.Chat.RollResult.Successes"}}</span>
                 <span class="arkham-total-value">{{successCount}}{{#if (gte successesNeeded 2)}} / {{successesNeeded}}{{/if}}</span>
             </div>
             <div class="arkham-total">
-                <span class="arkham-total-label">Failures</span>
+                <span class="arkham-total-label">{{localize "ARKHAM_HORROR.Chat.RollResult.Failures"}}</span>
                 <span class="arkham-total-value">{{failureCount}}</span>
             </div>
             <div class="arkham-total">
-                <span class="arkham-total-label">Trauma</span>
+                <span class="arkham-total-label">{{localize "ARKHAM_HORROR.Chat.RollResult.Trauma"}}</span>
                 <span class="arkham-total-value">{{horrorFailureCount}}</span>
             </div>
         </div>
@@ -171,18 +176,18 @@
             
             <div class="arkham-totals-weapon">
                 <div class="arkham-total">
-                    <span class="arkham-total-label">Damage</span>
+                    <span class="arkham-total-label">{{localize "ARKHAM_HORROR.Chat.RollResult.Damage"}}</span>
                     <span class="arkham-total-value">{{weaponDamage}}</span>
                 </div>
                 <div class="arkham-total">
-                    <span class="arkham-total-label">Inflict Injury</span>
+                    <span class="arkham-total-label">{{localize "ARKHAM_HORROR.Chat.RollResult.InflictInjury"}}</span>
                     <span class="arkham-total-value">{{#if weaponInflictInjury}}<i class="fas fa-check"></i>{{else}}<i class="fas fa-times"></i>{{/if}}</span>
                 </div>
             </div>
 
             {{#if weaponHasSpecialRules}}
                 <div class="arkham-weapon-special-rules">
-                    <strong>Special Rules:</strong>
+                    <strong>{{localize "ARKHAM_HORROR.PROPS.SpecialRules"}}:</strong>
                     <p>{{{weaponSpecialRules}}}</p>
                 </div>
             {{/if}}
@@ -196,7 +201,7 @@
             </header>
             {{#if spellHasSpecialRules}}
                 <div class="arkham-weapon-special-rules">
-                    <strong>Special Rules:</strong>
+                    <strong>{{localize "ARKHAM_HORROR.PROPS.SpecialRules"}}:</strong>
                     <p>{{{spellSpecialRules}}}</p>
                 </div>
             {{/if}}
@@ -205,9 +210,9 @@
 
         <footer class="arkham-roll-footer">
             {{#if isReroll}}
-                <span class="arkham-roll-footer-right">Dice Pool: unchanged (reroll)</span>
+                <span class="arkham-roll-footer-right">{{localize "ARKHAM_HORROR.Chat.RollResult.DicePoolUnchangedReroll"}}</span>
             {{else}}
-                <span class="arkham-roll-footer-right">Dice Pool: {{oldDicePoolValue}} → {{newDicePoolValue}}</span>
+                <span class="arkham-roll-footer-right">{{localize "ARKHAM_HORROR.Chat.RollResult.DicePoolChanged" oldDicePoolValue=oldDicePoolValue newDicePoolValue=newDicePoolValue}}</span>
             {{/if}}
         </footer>
     </div>

--- a/templates/combat/combat-footer.hbs
+++ b/templates/combat/combat-footer.hbs
@@ -1,19 +1,19 @@
 <nav class="combat-controls" data-tooltip-direction="UP">
   {{#if side.canControl}}
     {{#if side.started}}
-      <button type="button" class="combat-control combat-control-lg" data-action="endSidePhase" data-tooltip="End {{side.activeLabel}} Phase">
+      <button type="button" class="combat-control combat-control-lg" data-action="endSidePhase" data-tooltip="{{localize "ARKHAM_HORROR.COMBAT.EndActivePhase" label=side.activeLabel}}">
         <i class="fa-solid fa-check" inert></i>
-        <span>End Phase</span>
+        <span>{{localize "ARKHAM_HORROR.COMBAT.EndPhase"}}</span>
       </button>
 
-      <button type="button" class="combat-control combat-control-lg" data-action="endCombat" data-tooltip="End Combat">
+      <button type="button" class="combat-control combat-control-lg" data-action="endCombat" data-tooltip="{{localize "ARKHAM_HORROR.COMBAT.EndCombat"}}">
         <i class="fa-solid fa-flag-checkered" inert></i>
-        <span>End Combat</span>
+        <span>{{localize "ARKHAM_HORROR.COMBAT.EndCombat"}}</span>
       </button>
     {{else}}
       <button type="button" class="combat-control combat-control-lg" data-action="beginSideCombat">
         <i class="fa-solid fa-swords" inert></i>
-        <span>Begin Combat</span>
+        <span>{{localize "ARKHAM_HORROR.COMBAT.BeginCombat"}}</span>
       </button>
     {{/if}}
   {{/if}}

--- a/templates/combat/combat-tracker.hbs
+++ b/templates/combat/combat-tracker.hbs
@@ -5,8 +5,8 @@
       <div class="flexrow">
         <div class="combat-group-title flex1">{{group.label}}</div>
         {{#if @first}}
-          <div class="token-initiative" data-tooltip="Dice Pool">
-            <span class="initiative">DP</span>
+          <div class="token-initiative" data-tooltip="{{localize "ARKHAM_HORROR.LABELS.Dicepool"}}">
+            <span class="initiative">{{localize "ARKHAM_HORROR.ABBR.Dicepool"}}</span>
           </div>
         {{/if}}
       </div>
@@ -35,7 +35,7 @@
           </div>
         </div>
 
-        <div class="token-initiative" data-tooltip="Dicepool">
+        <div class="token-initiative" data-tooltip="{{localize "ARKHAM_HORROR.LABELS.Dicepool"}}">
           <span class="initiative">{{turn.dicepool}}</span>
         </div>
       </li>

--- a/templates/dice-roll-app/dialog.hbs
+++ b/templates/dice-roll-app/dialog.hbs
@@ -1,6 +1,6 @@
 <form class="roll-dialog-container scrollable">
     <div class="form-group">
-        <label for="dicepool">Dice Pool</label>
+        <label for="dicepool">{{localize "ARKHAM_HORROR.LABELS.Dicepool"}}</label>
         <div class="flexrow">
             <button class="button-dicepool-rolldialog" data-action="clickedDecreaseDicePool" {{#if isReaction}}disabled{{/if}}>-</button>
             <input type="number" id="dicepool" name="diceToUse" value="{{diceToUse}}" min="0" {{#if isReaction}}readonly{{/if}}> / 
@@ -9,11 +9,11 @@
         </div>
     </div>
     <div class="form-group">
-        <label for="roll-kind">Roll Type</label>
+        <label for="roll-kind">{{localize "ARKHAM_HORROR.PROPS.RollType"}}</label>
         <input type="text" id="roll-kind" name="rollKindLabel" value="{{rollKindLabel}}" readonly>
     </div>
     <div class="form-group">
-        <label for="skill-key">Skill</label>
+        <label for="skill-key">{{localize "ARKHAM_HORROR.PROPS.Skill"}}</label>
         {{#if isSkillSelectable}}
         <select id="skill-key" name="skillKey">
             {{#each skillChoices as |choice|}}
@@ -25,64 +25,64 @@
         {{/if}}
     </div>
     <div class="form-group">
-        <label for="skill-current">Success on X+</label>
+        <label for="skill-current">{{localize "ARKHAM_HORROR.PROPS.SuccessOnXPlus"}}</label>
         <input type="number" id="skill-current" name="skillCurrent" value="{{skillCurrent}}" min="0">
     </div>
     <div class="form-group">
-        <label for="bonus_dice">Bonus Dice</label>
+        <label for="bonus_dice">{{localize "ARKHAM_HORROR.PROPS.BonusDice"}}</label>
         <input type="number" id="bonus_dice" name="bonus_dice" value="{{bonus_dice}}" min="0">
     </div>
     <div class="form-group">
-        <label for="penalty">Penalty</label>
+        <label for="penalty">{{localize "ARKHAM_HORROR.PROPS.Penalty"}}</label>
         <input type="number" id="penalty" name="penalty" value="{{penalty}}" min="0">
     </div>
     <div class="form-group">
-        <label for="result-modifier">Result Modifier</label>
+        <label for="result-modifier">{{localize "ARKHAM_HORROR.PROPS.ResultModifier"}}</label>
         <input type="number" id="result-modifier" name="resultModifier" value="{{resultModifier}}" min="0" max="6" step="1">
     </div>
     <div class="form-group">
-        <label for="difficulty">Difficulty</label>
+        <label for="difficulty">{{localize "ARKHAM_HORROR.PROPS.Difficulty"}}</label>
         <select id="difficulty" name="difficulty">
-            <option value="1" {{#if (eq successesNeeded 1)}}selected{{/if}}>Normal (1)</option>
-            <option value="2" {{#if (eq successesNeeded 2)}}selected{{/if}}>Difficult (2)</option>
-            <option value="3" {{#if (eq successesNeeded 3)}}selected{{/if}}>Very Difficult (3)</option>
+            <option value="1" {{#if (eq successesNeeded 1)}}selected{{/if}}>{{localize "ARKHAM_HORROR.DIFFICULTY.Normal"}}</option>
+            <option value="2" {{#if (eq successesNeeded 2)}}selected{{/if}}>{{localize "ARKHAM_HORROR.DIFFICULTY.Difficult"}}</option>
+            <option value="3" {{#if (eq successesNeeded 3)}}selected{{/if}}>{{localize "ARKHAM_HORROR.DIFFICULTY.VeryDifficult"}}</option>
         </select>
     </div>
     <div class="form-group">
-        <label for="modifier">Advantage</label>
+        <label for="modifier">{{localize "ARKHAM_HORROR.PROPS.Advantage"}}</label>
         <select id="modifier" name="advantageModifier">
-            <option value="0" {{#if (eq modifierAdvantage 0)}}selected{{/if}}>None</option>
-            <option value="1" {{#if (eq modifierAdvantage 1)}}selected{{/if}}>Advantage</option>
-            <option value="2" {{#if (eq modifierAdvantage 2)}}selected{{/if}}>Disadvantage</option>
-            <option value="3" {{#if (eq modifierAdvantage 3)}}selected{{/if}}>Adv + Disadvantage</option>
+            <option value="0" {{#if (eq modifierAdvantage 0)}}selected{{/if}}>{{localize "ARKHAM_HORROR.Dialog.DiceRoll.None"}}</option>
+            <option value="1" {{#if (eq modifierAdvantage 1)}}selected{{/if}}>{{localize "ARKHAM_HORROR.PROPS.Advantage"}}</option>
+            <option value="2" {{#if (eq modifierAdvantage 2)}}selected{{/if}}>{{localize "ARKHAM_HORROR.PROPS.Disadvantage"}}</option>
+            <option value="3" {{#if (eq modifierAdvantage 3)}}selected{{/if}}>{{localize "ARKHAM_HORROR.Dialog.DiceRoll.AdvPlusDisadv"}}</option>
         </select>
     </div>
     {{#if weaponToUse}}
     <div class="form-group">
-        <label for="weapon-to-use">Weapon</label>
+        <label for="weapon-to-use">{{localize "ARKHAM_HORROR.PROPS.Weapon"}}</label>
         <input type="text" id="weapon-to-use" name="weaponToUse" value="{{weaponToUse.name}}" readonly>
     </div>
     {{/if}}
     {{#if spellToUse}}
     <div class="form-group">
-        <label for="spell-to-use">Spell</label>
+        <label for="spell-to-use">{{localize "ARKHAM_HORROR.PROPS.Spell"}}</label>
         <input type="text" id="spell-to-use" name="spellToUse" value="{{spellToUse.name}}" readonly>
     </div>
     {{/if}}
 
     <footer class="dialog-footer dialog-footer--primary">
-        <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> Roll</button>
+        <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> {{localize "ARKHAM_HORROR.ACTIONS.Roll"}}</button>
     </footer>
 
     {{#if knackChoices}}
     <hr />
     <div class="form-group knack-choices">
-        <label>Knacks</label>
-        <div class="notes">Select Knacks to apply. Uses are spent when you roll.</div>
+        <label>{{localize "ARKHAM_HORROR.LABELS.Knacks"}}</label>
+        <div class="notes">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.KnacksHint"}}</div>
 
         {{#if knackPreview.hasSelection}}
         <div class="knack-preview">
-            <div class="knack-preview__title">Selected effects</div>
+            <div class="knack-preview__title">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.SelectedEffects"}}</div>
             <div class="knack-preview__text">{{knackPreview.text}}</div>
         </div>
         {{/if}}
@@ -91,7 +91,7 @@
         <div class="flexrow knack-choice-row {{#if k.checked}}is-checked{{/if}} {{#if k.disabled}}is-disabled{{/if}}">
             <input type="checkbox" name="selectedKnackIds" value="{{k.id}}" {{#if k.checked}}checked{{/if}} {{#if k.disabled}}disabled{{/if}}>
             <span>
-                Tier {{k.tier}} - {{k.name}}
+                {{localize "ARKHAM_HORROR.Dialog.DiceRoll.Tier" tier=k.tier}} - {{k.name}}
                 {{#if k.effect}}
                     <span class="knack-effect">— {{k.effect.text}}</span>
                 {{/if}}
@@ -111,7 +111,7 @@
             </span>
 
             {{#if k.showRefresh}}
-            <button type="button" class="knack-refresh" data-action="refreshKnackUses" data-item-id="{{k.id}}" title="Refresh uses" aria-label="Refresh uses">
+            <button type="button" class="knack-refresh" data-action="refreshKnackUses" data-item-id="{{k.id}}" title="{{localize "ARKHAM_HORROR.Dialog.DiceRoll.RefreshUses"}}" aria-label="{{localize "ARKHAM_HORROR.Dialog.DiceRoll.RefreshUses"}}">
                 <i class="fas fa-rotate-right"></i>
             </button>
             {{/if}}

--- a/templates/injury-trauma-roll-app/dialog.hbs
+++ b/templates/injury-trauma-roll-app/dialog.hbs
@@ -1,22 +1,22 @@
 <form class="roll-dialog-container scrollable">
   <div class="form-group">
-    <label>Roll Type</label>
+    <label>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.RollType"}}</label>
     <select name="rollKind">
-      <option value="injury" {{#if (eq rollKind "injury")}}selected{{/if}}>Injury</option>
-      <option value="trauma" {{#if (eq rollKind "trauma")}}selected{{/if}}>Trauma</option>
+      <option value="injury" {{#if (eq rollKind "injury")}}selected{{/if}}>{{localize "TYPES.Item.injury"}}</option>
+      <option value="trauma" {{#if (eq rollKind "trauma")}}selected{{/if}}>{{localize "TYPES.Item.trauma"}}</option>
     </select>
   </div>
 
   <div class="form-group">
-    <label>Mode</label>
+    <label>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.Mode"}}</label>
     <select name="rollMode">
-      <option value="standard" {{#if (eq rollMode "standard")}}selected{{/if}}>Standard</option>
-      <option value="falling" {{#if (eq rollMode "falling")}}selected{{/if}}>Falling</option>
+      <option value="standard" {{#if (eq rollMode "standard")}}selected{{/if}}>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.Standard"}}</option>
+      <option value="falling" {{#if (eq rollMode "falling")}}selected{{/if}}>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.Falling"}}</option>
     </select>
   </div>
 
   <div class="form-group" data-roll-mode="standard">
-    <label>Die</label>
+    <label>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.Die"}}</label>
     <select name="dieFaces">
       <option value="6" {{#if (eq dieFaces 6)}}selected{{/if}}>d6</option>
       <option value="3" {{#if (eq dieFaces 3)}}selected{{/if}}>d3</option>
@@ -24,12 +24,12 @@
   </div>
 
   <div class="form-group" data-roll-mode="falling">
-    <label>Falling Height (ft)</label>
+    <label>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.FallingHeightFt"}}</label>
     <input type="number" name="fallingHeightFt" value="{{fallingHeightFt}}" min="10" step="1" />
   </div>
 
   <div class="form-group">
-    <label>Modifier</label>
+    <label>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.Modifier"}}</label>
     <input type="number" name="modifier" value="{{modifier}}" step="1" />
   </div>
 
@@ -38,6 +38,6 @@
   <p class="arkham-horror-hint" data-role="formulaHint">{{formulaHint}}</p>
 
   <footer class="dialog-footer">
-    <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> Roll</button>
+    <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> {{localize "ARKHAM_HORROR.ACTIONS.Roll"}}</button>
   </footer>
 </form>

--- a/templates/item/item-archetype-sheet.hbs
+++ b/templates/item/item-archetype-sheet.hbs
@@ -5,7 +5,7 @@
         <div class="flexcol" style="gap: 12px;">
 
             <fieldset>
-                <legend>SKILL CAPS</legend>
+                <legend>{{localize "ARKHAM_HORROR.ARCHETYPE.SkillCaps"}}</legend>
                 <div class="flexcol" style="gap: 8px;">
                     {{#each skillCapKeys as |skillKey|}}
                     <div class="form-group" style="margin: 0;">
@@ -17,19 +17,19 @@
             </fieldset>
 
             <fieldset>
-                <legend>Tier Purchase Limits</legend>
+                <legend>{{localize "ARKHAM_HORROR.ARCHETYPE.TierPurchaseLimits"}}</legend>
                 <div class="flexcol" style="gap: 12px;">
                     {{#each knackTiers as |t|}}
                     <div class="flexcol" style="gap: 8px;">
                         <div class="form-group" style="margin: 0;">
-                            <label for="tier{{@key}}Max">Tier {{@key}} Max</label>
+                            <label for="tier{{@key}}Max">{{localize "ARKHAM_HORROR.ARCHETYPE.TierMaxLabel" tier=@key}}</label>
                             <div class="form-fields">
                                 <input type="number" id="tier{{@key}}Max" name="system.knackTiers.{{@key}}.maxPurchasable" value="{{t.maxPurchasable}}" min="0" />
                             </div>
                         </div>
 
                         <div class="form-group" style="margin: 0;">
-                            <label for="tier{{@key}}Xp">Tier {{@key}} XP Cost</label>
+                            <label for="tier{{@key}}Xp">{{localize "ARKHAM_HORROR.ARCHETYPE.TierXpCostLabel" tier=@key}}</label>
                             <div class="form-fields">
                                 <input type="number" id="tier{{@key}}Xp" name="system.knackTiers.{{@key}}.xpcost" value="{{t.xpcost}}" min="0" />
                             </div>
@@ -39,9 +39,9 @@
                 </div>
             </fieldset>
             <fieldset>
-                <legend>Source</legend>
+                <legend>{{localize "ARKHAM_HORROR.Effect.Source"}}</legend>
                 <div class="form-group" style="margin: 0;">
-                    <label for="archetypeSource">Source</label>
+                    <label for="archetypeSource">{{localize "ARKHAM_HORROR.Effect.Source"}}</label>
                     <div class="form-fields">
                         <input type="text" id="archetypeSource" name="system.sourceBook" value="{{system.sourceBook}}" />
                     </div>
@@ -51,22 +51,22 @@
 
         <div class="flexcol" style="gap: 12px;">
             <fieldset>
-                <legend>KNACK TIERS</legend>
-                <p class="arkham-horror-hint">Drag &amp; drop Knack Items onto a tier below to add their UUID (no embedding). Click a knack name to view its description.</p>
+                <legend>{{localize "ARKHAM_HORROR.ARCHETYPE.KnackTiers"}}</legend>
+                <p class="arkham-horror-hint">{{localize "ARKHAM_HORROR.ARCHETYPE.DragDropHint"}}</p>
                 {{#each knackTiers as |tier tierNumber|}}
                 <fieldset class="archetype-tier-drop" data-archetype-tier="{{tierNumber}}">
-                    <legend>Tier {{tierNumber}}</legend>
+                    <legend>{{localize "ARKHAM_HORROR.Dialog.DiceRoll.Tier" tier=tierNumber}}</legend>
 
                     {{#each tier.allowedKnacks as |k|}}
                     <div class="knack-entry" draggable="true" data-drag-type="archetype-knack" data-uuid="{{k.uuid}}" data-tier="{{k.tier}}">
                         <div>
-                            <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="archetypeKnack{{tierNumber}}-{{@index}}">Tier {{k.tier}} - {{k.name}}</strong>
+                            <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="archetypeKnack{{tierNumber}}-{{@index}}">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.Tier" tier=k.tier}} - {{k.name}}</strong>
                             <span class="small">({{k.sourceLabel}})</span>
                             {{#if ../../isGM}}
-                            <a class="item-control" data-action="openUuidItem" data-uuid="{{k.uuid}}" title="View/Edit">
+                            <a class="item-control" data-action="openUuidItem" data-uuid="{{k.uuid}}" title="{{localize "ARKHAM_HORROR.ACTIONS.ViewEdit"}}" aria-label="{{localize "ARKHAM_HORROR.ACTIONS.ViewEdit"}}">
                                 <i class="fas fa-edit"></i>
                             </a>
-                            <a class="item-control" data-action="removeArchetypeKnack" data-tier="{{tierNumber}}" data-uuid="{{k.uuid}}" title="Remove">
+                            <a class="item-control" data-action="removeArchetypeKnack" data-tier="{{tierNumber}}" data-uuid="{{k.uuid}}" title="{{localize "ARKHAM_HORROR.ACTIONS.Remove"}}" aria-label="{{localize "ARKHAM_HORROR.ACTIONS.Remove"}}">
                                 <i class="fas fa-trash"></i>
                             </a>
                             {{/if}}

--- a/templates/item/item-feature-sheet.hbs
+++ b/templates/item/item-feature-sheet.hbs
@@ -2,15 +2,15 @@
   <header class="sheet-header">
     <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
     <div class="header-fields">
-      <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
+      <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "ARKHAM_HORROR.PROPS.Name"}}"/></h1>
     </div>
   </header>
 
   {{!-- Sheet Tab Navigation --}}
   <nav class="sheet-tabs tabs" data-group="primary">
-    <a class="item" data-tab="description">Description</a>
-    <a class="item" data-tab="attributes">Attributes</a>
-    <a class="item" data-tab="effects">Effects</a>
+    <a class="item" data-tab="description">{{localize "ARKHAM_HORROR.TABS.Description"}}</a>
+    <a class="item" data-tab="attributes">{{localize "ARKHAM_HORROR.TABS.Attributes"}}</a>
+    <a class="item" data-tab="effects">{{localize "ARKHAM_HORROR.TABS.Effects"}}</a>
   </nav>
 
   {{!-- Sheet Body --}}

--- a/templates/item/item-item-sheet.hbs
+++ b/templates/item/item-item-sheet.hbs
@@ -11,11 +11,11 @@
           name='name'
           type='text'
           value='{{item.name}}'
-          placeholder='Name'
+          placeholder='{{localize "ARKHAM_HORROR.PROPS.Name"}}'
         /></h1>
       <div class='grid grid-2col'>
         <div class='resource'>
-          <label class='resource-label'>Quantity</label>
+          <label class='resource-label'>{{localize "ARKHAM_HORROR.PROPS.Quantity"}}</label>
           <input
             type='text'
             name='system.quantity'
@@ -24,7 +24,7 @@
           />
         </div>
         <div class='resource'>
-          <label class='resource-label'>Weight</label>
+          <label class='resource-label'>{{localize "ARKHAM_HORROR.PROPS.Weight"}}</label>
           <input
             type='text'
             name='system.weight'
@@ -38,8 +38,8 @@
 
   {{! Sheet Tab Navigation }}
   <nav class='sheet-tabs tabs' data-group='primary'>
-    <a class='item' data-tab='description'>Description</a>
-    <a class='item' data-tab='attributes'>Attributes</a>
+    <a class='item' data-tab='description'>{{localize "ARKHAM_HORROR.TABS.Description"}}</a>
+    <a class='item' data-tab='attributes'>{{localize "ARKHAM_HORROR.TABS.Attributes"}}</a>
   </nav>
 
   {{! Sheet Body }}
@@ -61,11 +61,11 @@
     <div class='tab attributes' data-group='primary' data-tab='attributes'>
       {{! As you add new fields, add them in here! }}
       <div class='resource'>
-        <label class='resource-label'>Roll Formula:</label>
+        <label class='resource-label'>{{localize "ARKHAM_HORROR.PROPS.RollFormula"}}:</label>
         <span>{{system.formula}}</span>
         <div class='grid grid-4col'>
           <div class='grid-span-1'>
-            <label class='resource-label'>Number of Dice</label>
+            <label class='resource-label'>{{localize "ARKHAM_HORROR.PROPS.NumberOfDice"}}</label>
             <input
               type='text'
               name='system.roll.diceNum'
@@ -74,7 +74,7 @@
             />
           </div>
           <div class='grid-span-1'>
-            <label class='resource-label'>Die Size</label>
+            <label class='resource-label'>{{localize "ARKHAM_HORROR.PROPS.DieSize"}}</label>
             <input
               type='text'
               name='system.roll.diceSize'
@@ -83,7 +83,7 @@
             />
           </div>
           <div class='grid-span-2'>
-            <label class='resource-label'>Roll Modifier</label>
+            <label class='resource-label'>{{localize "ARKHAM_HORROR.PROPS.RollModifier"}}</label>
             <input
               type='text'
               name='system.roll.diceBonus'

--- a/templates/item/item-knack-sheet.hbs
+++ b/templates/item/item-knack-sheet.hbs
@@ -2,21 +2,21 @@
     data-group="{{tabs.form.group}}">
     <div class="resource-group-styled knack-sheet">
         <div class="form-group">
-            <label for="tier" class="styled-label">Tier</label>
+            <label for="tier" class="styled-label">{{localize "ARKHAM_HORROR.PROPS.Tier"}}</label>
             <input type="number" id="tier" name="system.tier" value="{{system.tier}}">
         </div>
 
         <hr />
 
         <div class="resource-group knack-grants">
-            <h5 class="quick-label">Grants (Spells/Faith/Intuition)</h5>
-            <p class="notes">Drop Spell items here to have this Knack grant them on acquire.</p>
+            <h5 class="quick-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.Grants"}}</h5>
+            <p class="notes">{{localize "ARKHAM_HORROR.KNACK_SHEET.GrantsHint"}}</p>
 
             {{#if knackGrants}}
             <ol class='items-list'>
                 <li class='item flexrow items-header'>
-                    <div class='item-name'>Name</div>
-                    <div class='item-prop'>Source</div>
+                    <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
+                    <div class='item-prop'>{{localize "ARKHAM_HORROR.Effect.Source"}}</div>
                     <div class='item-controls'></div>
                 </li>
                 {{#each knackGrants as |spell|}}
@@ -24,10 +24,10 @@
                     <div class='item-name'>{{spell.name}}</div>
                     <div class='item-prop'>{{spell.sourceLabel}}</div>
                     <div class='item-controls'>
-                        <a class='item-control item-edit' data-action="openUuidItem" data-uuid="{{spell.uuid}}" title='{{localize "DOCUMENT.View" type=' spell'}}'>
+                        <a class='item-control item-edit' data-action="openUuidItem" data-uuid="{{spell.uuid}}" title='{{localize "DOCUMENT.View" type=(localize "TYPES.Item.spell")}}' aria-label='{{localize "DOCUMENT.View" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-eye'></i>
                         </a>
-                        <a class='item-control item-delete' data-action="removeKnackGrant" data-uuid="{{spell.uuid}}" title='{{localize "DOCUMENT.Delete" type=' spell'}}'>
+                        <a class='item-control item-delete' data-action="removeKnackGrant" data-uuid="{{spell.uuid}}" title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.spell")}}' aria-label='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -39,29 +39,29 @@
 
         <hr />
 
-        <h5 class="quick-label">Usage</h5>
+        <h5 class="quick-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.Usage"}}</h5>
         <div class="form-group">
-            <label for="usage-frequency" class="styled-label">Frequency</label>
+            <label for="usage-frequency" class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.Frequency"}}</label>
             <select id="usage-frequency" name="system.usage.frequency">
-                <option value="passive" {{#if (eq system.usage.frequency "passive")}}selected{{/if}}>Passive</option>
-                <option value="unlimited" {{#if (eq system.usage.frequency "unlimited")}}selected{{/if}}>Unlimited</option>
-                <option value="oncePerTurn" {{#if (eq system.usage.frequency "oncePerTurn")}}selected{{/if}}>Once Per Turn</option>
-                <option value="oncePerScene" {{#if (eq system.usage.frequency "oncePerScene")}}selected{{/if}}>Once Per Scene</option>
-                <option value="oncePerSession" {{#if (eq system.usage.frequency "oncePerSession")}}selected{{/if}}>Once Per Session</option>
+                <option value="passive" {{#if (eq system.usage.frequency "passive")}}selected{{/if}}>{{localize "ARKHAM_HORROR.KNACK_USAGE.passive"}}</option>
+                <option value="unlimited" {{#if (eq system.usage.frequency "unlimited")}}selected{{/if}}>{{localize "ARKHAM_HORROR.KNACK_USAGE.unlimited"}}</option>
+                <option value="oncePerTurn" {{#if (eq system.usage.frequency "oncePerTurn")}}selected{{/if}}>{{localize "ARKHAM_HORROR.KNACK_USAGE.oncePerTurn"}}</option>
+                <option value="oncePerScene" {{#if (eq system.usage.frequency "oncePerScene")}}selected{{/if}}>{{localize "ARKHAM_HORROR.KNACK_USAGE.oncePerScene"}}</option>
+                <option value="oncePerSession" {{#if (eq system.usage.frequency "oncePerSession")}}selected{{/if}}>{{localize "ARKHAM_HORROR.KNACK_USAGE.oncePerSession"}}</option>
             </select>
         </div>
         <div class="form-group">
-            <label for="usage-max" class="styled-label">Max Uses</label>
+            <label for="usage-max" class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.MaxUses"}}</label>
             <input type="number" id="usage-max" name="system.usage.max" value="{{system.usage.max}}" min="0">
         </div>
         <div class="form-group">
-            <label for="usage-remaining" class="styled-label">Remaining</label>
+            <label for="usage-remaining" class="styled-label">{{localize "ARKHAM_HORROR.LABELS.Remaining"}}</label>
             <input type="number" id="usage-remaining" name="system.usage.remaining" value="{{system.usage.remaining}}" min="0">
         </div>
 
         <hr />
         
-        <h5 class="quick-label">NPC Knack Flags</h5>
+        <h5 class="quick-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.NpcKnackFlags"}}</h5>
         <div class="form-group">
             <label for="is-npc-knack" class="styled-label">{{localize "ITEM.Knack.isNPCknack"}}</label>
             <input type="checkbox" id="is-npc-knack" name="system.isNPCknack" {{#if system.isNPCknack}}checked{{/if}}>
@@ -74,18 +74,18 @@
 
         <hr />
 
-        <h5 class="quick-label">Roll Effects (Prompt-Selectable)</h5>
+        <h5 class="quick-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollEffectsPromptSelectable"}}</h5>
         <div class="form-group">
-            <label for="roll-effects-enabled" class="styled-label">Enabled</label>
+            <label for="roll-effects-enabled" class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.Enabled"}}</label>
             <input type="checkbox" id="roll-effects-enabled" name="system.rollEffects.enabled" {{#if system.rollEffects.enabled}}checked{{/if}}>
         </div>
 
         <div class="form-group">
-            <label class="styled-label">Applies to Skills</label>
+            <label class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.AppliesToSkills"}}</label>
             <div class="knack-picker" data-group="skillKeys">
                 <div class="knack-picker__controls">
                     <select class="knack-picker__select" name="_knackSkillKey">
-                        <option value="any">Any</option>
+                        <option value="any">{{localize "ARKHAM_HORROR.KNACK_SHEET.Any"}}</option>
                         <option value="agility">{{localize "ARKHAM_HORROR.SKILL.agility"}}</option>
                         <option value="athletics">{{localize "ARKHAM_HORROR.SKILL.athletics"}}</option>
                         <option value="wits">{{localize "ARKHAM_HORROR.SKILL.wits"}}</option>
@@ -99,74 +99,74 @@
                     </select>
                     <button type="button" class="knack-picker__add" data-action="addKnackRollEffectKey" data-group="skillKeys">+</button>
                 </div>
-                <div class="knack-picker__selected" aria-label="Selected skills">
+                <div class="knack-picker__selected" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.SelectedSkills"}}">
                     {{#each system.rollEffects.skillKeys as |k|}}
                         <span class="knack-pill" data-value="{{k}}">
                             {{#if (eq k "any")}}
-                                Any
+                                {{localize "ARKHAM_HORROR.KNACK_SHEET.Any"}}
                             {{else}}
                                 {{localize (concat "ARKHAM_HORROR.SKILL." k)}}
                             {{/if}}
-                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="skillKeys" data-value="{{k}}" title="Remove">
+                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="skillKeys" data-value="{{k}}" title="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}">
                                 <i class="fas fa-times"></i>
                             </a>
                         </span>
                     {{/each}}
                 </div>
-                <div class="notes">“Any” overrides other selections.</div>
+                <div class="notes">{{localize "ARKHAM_HORROR.KNACK_SHEET.AnyOverrides"}}</div>
             </div>
         </div>
 
         <div class="form-group">
-            <label class="styled-label">Applies to Roll Types</label>
+            <label class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.AppliesToRollTypes"}}</label>
             <div class="knack-picker" data-group="rollKinds">
                 <div class="knack-picker__controls">
                     <select class="knack-picker__select" name="_knackRollKind">
-                        <option value="any">Any</option>
-                        <option value="complex">Complex</option>
-                        <option value="reaction">Reaction</option>
+                        <option value="any">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Any"}}</option>
+                        <option value="complex">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Complex"}}</option>
+                        <option value="reaction">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Reaction"}}</option>
                     </select>
                     <button type="button" class="knack-picker__add" data-action="addKnackRollEffectKey" data-group="rollKinds">+</button>
                 </div>
-                <div class="knack-picker__selected" aria-label="Selected roll types">
+                <div class="knack-picker__selected" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.SelectedRollTypes"}}">
                     {{#each system.rollEffects.rollKinds as |k|}}
                         <span class="knack-pill" data-value="{{k}}">
                             {{#if (eq k "any")}}
-                                Any
+                                {{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Any"}}
                             {{else}}
-                                {{#if (eq k "complex")}}Complex{{/if}}
-                                {{#if (eq k "reaction")}}Reaction{{/if}}
-                                {{#if (eq k "tome-understand")}}Tome: Understand{{/if}}
-                                {{#if (eq k "tome-attune")}}Tome: Attune{{/if}}
+                                {{#if (eq k "complex")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Complex"}}{{/if}}
+                                {{#if (eq k "reaction")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Reaction"}}{{/if}}
+                                {{#if (eq k "tome-understand")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.TomeUnderstand"}}{{/if}}
+                                {{#if (eq k "tome-attune")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.TomeAttune"}}{{/if}}
                             {{/if}}
-                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="rollKinds" data-value="{{k}}" title="Remove">
+                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="rollKinds" data-value="{{k}}" title="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}">
                                 <i class="fas fa-times"></i>
                             </a>
                         </span>
                     {{/each}}
                 </div>
-                <div class="notes">“Any” overrides other selections.</div>
+                <div class="notes">{{localize "ARKHAM_HORROR.KNACK_SHEET.AnyOverrides"}}</div>
             </div>
         </div>
 
         <div class="form-group">
-            <label for="knack-bonus-dice" class="styled-label">Bonus Dice (delta)</label>
+            <label for="knack-bonus-dice" class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.BonusDiceDelta"}}</label>
             <input type="number" id="knack-bonus-dice" name="system.rollEffects.modifier.addBonusDice" value="{{system.rollEffects.modifier.addBonusDice}}" min="0">
         </div>
         <div class="form-group">
-            <label for="knack-result-mod" class="styled-label">Result Modifier (delta)</label>
+            <label for="knack-result-mod" class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.ResultModifierDelta"}}</label>
             <input type="number" id="knack-result-mod" name="system.rollEffects.modifier.resultModifier" value="{{system.rollEffects.modifier.resultModifier}}">
         </div>
         <div class="form-group">
-            <label class="styled-label">Advantage</label>
+            <label class="styled-label">{{localize "ARKHAM_HORROR.PROPS.Advantage"}}</label>
             <input type="checkbox" name="system.rollEffects.modifier.advantage" {{#if system.rollEffects.modifier.advantage}}checked{{/if}}>
         </div>
         <div class="form-group">
-            <label class="styled-label">Disadvantage</label>
+            <label class="styled-label">{{localize "ARKHAM_HORROR.PROPS.Disadvantage"}}</label>
             <input type="checkbox" name="system.rollEffects.modifier.disadvantage" {{#if system.rollEffects.modifier.disadvantage}}checked{{/if}}>
         </div>
         <div class="form-group">
-            <label for="knack-reroll-allow" class="styled-label">Reroll Allowance (dice)</label>
+            <label for="knack-reroll-allow" class="styled-label">{{localize "ARKHAM_HORROR.KNACK_SHEET.RerollAllowanceDice"}}</label>
             <input type="number" id="knack-reroll-allow" name="system.rollEffects.modifier.rerollAllowanceDice" value="{{system.rollEffects.modifier.rerollAllowanceDice}}" min="0">
         </div>
 

--- a/templates/item/item-relic-sheet.hbs
+++ b/templates/item/item-relic-sheet.hbs
@@ -7,10 +7,10 @@
         </div>
         <div class="form-group">
             <label for="rarity">{{localize "ITEM.Tome.rarity"}}</label>
-            Common<input type="checkbox" id="rarity" name="system.rarity.common" {{#if system.rarity.common}}checked{{/if}} />
-            Uncommon<input type="checkbox" id="rarity" name="system.rarity.uncommon" {{#if system.rarity.uncommon}}checked{{/if}} />
-            Rare<input type="checkbox" id="rarity" name="system.rarity.rare" {{#if system.rarity.rare}}checked{{/if}} />
-            Unique<input type="checkbox" id="rarity" name="system.rarity.unique" {{#if system.rarity.unique}}checked{{/if}} />
+            {{localize "ARKHAM_HORROR.RARITY.common"}}<input type="checkbox" id="rarity" name="system.rarity.common" {{#if system.rarity.common}}checked{{/if}} />
+            {{localize "ARKHAM_HORROR.RARITY.uncommon"}}<input type="checkbox" id="rarity" name="system.rarity.uncommon" {{#if system.rarity.uncommon}}checked{{/if}} />
+            {{localize "ARKHAM_HORROR.RARITY.rare"}}<input type="checkbox" id="rarity" name="system.rarity.rare" {{#if system.rarity.rare}}checked{{/if}} />
+            {{localize "ARKHAM_HORROR.RARITY.unique"}}<input type="checkbox" id="rarity" name="system.rarity.unique" {{#if system.rarity.unique}}checked{{/if}} />
         </div>
 
         <div class="form-group">

--- a/templates/item/item-sheet.hbs
+++ b/templates/item/item-sheet.hbs
@@ -13,15 +13,15 @@
           name='name'
           type='text'
           value='{{item.name}}'
-          placeholder='Name'
+          placeholder='{{localize "ARKHAM_HORROR.PROPS.Name"}}'
         /></h1>
     </div>
   </header>
 
   {{! Sheet Tab Navigation }}
   <nav class='sheet-tabs tabs' data-group='primary'>
-    <a class='item' data-tab='description'>Description</a>
-    <a class='item' data-tab='attributes'>Attributes</a>
+    <a class='item' data-tab='description'>{{localize "ARKHAM_HORROR.TABS.Description"}}</a>
+    <a class='item' data-tab='attributes'>{{localize "ARKHAM_HORROR.TABS.Attributes"}}</a>
   </nav>
 
   {{! Sheet Body }}

--- a/templates/item/item-spell-sheet.hbs
+++ b/templates/item/item-spell-sheet.hbs
@@ -10,9 +10,9 @@
         <div class="form-group">
             <label for="difficulty">{{localize "ITEM.Spell.difficulty"}}</label>
             <select id="difficulty" name="system.difficulty">
-                <option value="1" {{#if (eq system.difficulty 1)}}selected{{/if}}>Normal (1)</option>
-                <option value="2" {{#if (eq system.difficulty 2)}}selected{{/if}}>Difficult (2)</option>
-                <option value="3" {{#if (eq system.difficulty 3)}}selected{{/if}}>Very Difficult (3)</option>
+                <option value="1" {{#if (eq system.difficulty 1)}}selected{{/if}}>{{localize "ARKHAM_HORROR.DIFFICULTY.Normal"}}</option>
+                <option value="2" {{#if (eq system.difficulty 2)}}selected{{/if}}>{{localize "ARKHAM_HORROR.DIFFICULTY.Difficult"}}</option>
+                <option value="3" {{#if (eq system.difficulty 3)}}selected{{/if}}>{{localize "ARKHAM_HORROR.DIFFICULTY.VeryDifficult"}}</option>
             </select>
         </div>
         <div class="form-group">

--- a/templates/item/item-tome-sheet.hbs
+++ b/templates/item/item-tome-sheet.hbs
@@ -8,12 +8,12 @@
         </div>
         <div class="form-group">
             <label for="rarity">{{localize "ITEM.Tome.rarity"}}</label>
-            Common<input type="checkbox" id="rarity" name="system.rarity.common" {{#if
+            {{localize "ARKHAM_HORROR.RARITY.common"}}<input type="checkbox" id="rarity" name="system.rarity.common" {{#if
                 system.rarity.common}}checked{{/if}} />
-            Uncommon<input type="checkbox" id="rarity" name="system.rarity.uncommon" {{#if
+            {{localize "ARKHAM_HORROR.RARITY.uncommon"}}<input type="checkbox" id="rarity" name="system.rarity.uncommon" {{#if
                 system.rarity.uncommon}}checked{{/if}} />
-            Rare<input type="checkbox" id="rarity" name="system.rarity.rare" {{#if system.rarity.rare}}checked{{/if}} />
-            Unique<input type="checkbox" id="rarity" name="system.rarity.unique" {{#if
+            {{localize "ARKHAM_HORROR.RARITY.rare"}}<input type="checkbox" id="rarity" name="system.rarity.rare" {{#if system.rarity.rare}}checked{{/if}} />
+            {{localize "ARKHAM_HORROR.RARITY.unique"}}<input type="checkbox" id="rarity" name="system.rarity.unique" {{#if
                 system.rarity.unique}}checked{{/if}} />
         </div>
 
@@ -89,7 +89,7 @@
 
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ITEM.Tome.source"}}</div>
                 <div class='item-controls'></div>
             </li>
@@ -104,12 +104,12 @@
                     <div class='item-prop'>{{spell.sourceLabel}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="openUuidItem" data-uuid="{{spell.uuid}}"
-                            title='{{localize "DOCUMENT.View" type=' spell'}}'>
+                            title='{{localize "DOCUMENT.View" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-eye'></i>
                         </a>
                         {{#if ../isGM}}
                         <a class='item-control item-delete' data-action="removeTomeSpell" data-uuid="{{spell.uuid}}"
-                            title='{{localize "DOCUMENT.Delete" type=' spell'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                         {{/if}}

--- a/templates/item/item-useful_item-sheet.hbs
+++ b/templates/item/item-useful_item-sheet.hbs
@@ -2,7 +2,7 @@
     data-group="{{tabs.form.group}}">
     <div class="resource-group-styled">
         <div class="form-group">
-            <label for="has-special-rules">Has Special Rules</label>
+            <label for="has-special-rules">{{localize "ARKHAM_HORROR.PROPS.HasSpecialRules"}}</label>
             <input type="checkbox" id="has-special-rules" name="system.hasSpecialRules" {{#if system.hasSpecialRules}}checked{{/if}} />
         </div>
         <div class="form-group">

--- a/templates/item/parts/item-effects.hbs
+++ b/templates/item/parts/item-effects.hbs
@@ -5,8 +5,8 @@
       <div class="effect-source">{{localize "ARKHAM_HORROR.Effect.Source"}}</div>
       <div class="effect-source">{{localize "EFFECT.TabDuration"}}</div>
       <div class="item-controls effect-controls flexrow">
-        <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type="Effect"}}">
-          <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type="Effect"}}
+        <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type=(localize 'DOCUMENT.ActiveEffect')}}">
+          <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type=(localize "DOCUMENT.ActiveEffect")}}
         </a>
       </div>
     </li>
@@ -24,10 +24,10 @@
           <a class="effect-control" data-action="toggle" title="{{localize 'ARKHAM_HORROR.Effect.Toggle'}}">
             <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
           </a>
-          <a class="effect-control" data-action="edit" title="{{localize 'DOCUMENT.Update' type="Effect"}}">
+          <a class="effect-control" data-action="edit" title="{{localize 'DOCUMENT.Update' type=(localize 'DOCUMENT.ActiveEffect')}}">
             <i class="fas fa-edit"></i>
           </a>
-          <a class="effect-control" data-action="delete" title="{{localize 'DOCUMENT.Delete' type="Effect"}}">
+          <a class="effect-control" data-action="delete" title="{{localize 'DOCUMENT.Delete' type=(localize 'DOCUMENT.ActiveEffect')}}">
             <i class="fas fa-trash"></i>
           </a>
         </div>

--- a/templates/item/parts/item-header.hbs
+++ b/templates/item/parts/item-header.hbs
@@ -1,6 +1,6 @@
 <header class="item-header">
     <div class="flexrow">
     <img class="item-img" data-action="editImage" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="60"/>
-    <h2 class="charname" style="flex-grow: 4;"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h2>
+    <h2 class="charname" style="flex-grow: 4;"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "ARKHAM_HORROR.PROPS.Name"}}" /></h2>
     </div>
 </header>

--- a/templates/npc/parts/_skill.hbs
+++ b/templates/npc/parts/_skill.hbs
@@ -1,7 +1,13 @@
 <div class="npc-skill-entry flexrow">
-    <label class="npc-skill clickable" data-action="clickSkill" data-skill-key="{{skillKey}}">{{label}}</label>
-    <input type="number" name="system.skills.{{skillKey}}.current" value="{{skillData.current}}" data-dtype="Number" title="Limit">
-    <div class="skill-reaction-icon clickable" data-action="clickSkillReaction" data-skill-key="{{skillKey}}" title="Reaction roll">
+    <label class="npc-skill clickable" data-action="clickSkill" data-skill-key="{{skillKey}}">
+        {{#if label}}
+            {{label}}
+        {{else}}
+            {{localize (concat "ARKHAM_HORROR.SKILL_SHORT." skillKey)}}
+        {{/if}}
+    </label>
+    <input type="number" name="system.skills.{{skillKey}}.current" value="{{skillData.current}}" data-dtype="Number" title="{{localize "ARKHAM_HORROR.LABELS.Limit"}}">
+    <div class="skill-reaction-icon clickable" data-action="clickSkillReaction" data-skill-key="{{skillKey}}" title="{{localize "ARKHAM_HORROR.Chat.RollResult.ReactionRollTooltip"}}">
         <i class="fa-solid fa-arrow-rotate-left"></i>
     </div>
 </div>

--- a/templates/npc/parts/npc-header.hbs
+++ b/templates/npc/parts/npc-header.hbs
@@ -7,7 +7,7 @@
         {{!-- Edit Mode Layout --}}
         <div class="title">
             <h1 class="charname"><input name="name" type="text" value="{{actor.name}}"
-                    placeholder="{{localize 'MIST_ENGINE.PLACEHOLDERS.Name'}}" /></h1>
+                    placeholder="{{localize "ARKHAM_HORROR.PROPS.Name"}}" /></h1>
         </div>
         <div class="resource-group-styled grid grid-8col">
             <div class="archetype-entry grid-span-5">

--- a/templates/npc/parts/npc-main.hbs
+++ b/templates/npc/parts/npc-main.hbs
@@ -2,31 +2,31 @@
     data-group="{{tabs.npc.group}}">
     <div class="resource-group-styled grid grid-5col">
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='agility'
-        skillData=system.skills.agility label="AGI"}}
+        skillData=system.skills.agility}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='athletics'
-        skillData=system.skills.athletics label="ATH"}}
+        skillData=system.skills.athletics}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='wits'
-        skillData=system.skills.wits label="WIT"}}
+        skillData=system.skills.wits}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='presence'
-        skillData=system.skills.presence label="PRES"}}
+        skillData=system.skills.presence}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='intuition'
-        skillData=system.skills.intuition label="INT"}}
+        skillData=system.skills.intuition}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='knowledge'
-        skillData=system.skills.knowledge label="KNOW"}}
+        skillData=system.skills.knowledge}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='resolve'
-        skillData=system.skills.resolve label="RES"}}
+        skillData=system.skills.resolve}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='meleeCombat'
-        skillData=system.skills.meleeCombat label="MELEE"}}
+        skillData=system.skills.meleeCombat}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='rangedCombat'
-        skillData=system.skills.rangedCombat label="RANGED"}}
+        skillData=system.skills.rangedCombat}}
         {{> systems/arkham-horror-rpg-fvtt/templates/npc/parts/_skill.hbs skillKey='lore'
-        skillData=system.skills.lore label="LORE"}}
+        skillData=system.skills.lore}}
     </div>
     <div class="grid grid-2col">
         <div>
             <fieldset>
-                <legend>KNACKS <a class='item-control item-create' data-action="createNpcKnack"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
+                <legend>{{localize "ARKHAM_HORROR.LABELS.Knacks"}} <a class='item-control item-create' data-action="createNpcKnack"
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.knack")}}'>
                         <i class='fas fa-plus'></i>
                     </a></legend>
                 {{#each knacks as |knack|}}
@@ -35,11 +35,11 @@
                         <strong class="clickable" data-action="toggleFoldableContent"
                             data-fc-id="knack{{knack._id}}">{{knack.name}} </strong>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' knack'}}' data-item-id='{{knack._id}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.knack")}}' data-item-id='{{knack._id}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' knack'}}' data-item-id='{{knack._id}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.knack")}}' data-item-id='{{knack._id}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -55,7 +55,7 @@
             <fieldset>
                 <legend>{{localize "ARKHAM_HORROR.LABELS.Weaknesses"}}
                     <a class='item-control item-create' data-action="createWeakness"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "ARKHAM_HORROR.NPC.Weakness")}}'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </legend>
@@ -65,11 +65,11 @@
                         <strong class="clickable" data-action="toggleFoldableContent"
                             data-fc-id="weakness{{knack._id}}">{{knack.name}} </strong>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' knack'}}' data-item-id='{{knack._id}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "ARKHAM_HORROR.NPC.Weakness")}}' data-item-id='{{knack._id}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' knack'}}' data-item-id='{{knack._id}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "ARKHAM_HORROR.NPC.Weakness")}}' data-item-id='{{knack._id}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -83,7 +83,7 @@
             <fieldset>
                 <legend>
                     {{localize "ARKHAM_HORROR.LABELS.InjuriesTrauma"}}
-                    <a class='item-control' data-action="clickedInjuryTraumaRoll" title="Roll Injury/Trauma">
+                    <a class='item-control' data-action="clickedInjuryTraumaRoll" title="{{localize "ARKHAM_HORROR.ACTIONS.RollInjuryTrauma"}}" aria-label="{{localize "ARKHAM_HORROR.ACTIONS.RollInjuryTrauma"}}">
                         <i class="fa-solid fa-dice"></i>
                     </a>
                 </legend>
@@ -91,15 +91,14 @@
                 <div class="injury-entry">
                     <div>
                         <strong class="clickable" data-action="toggleFoldableContent" data-fc-id="injury{{injury._id}}">
-                            {{#if (eq injury.type 'trauma')}}[TRAUMA] {{/if}}
-                            {{#if (eq injury.type 'injury')}}[INJURY] {{/if}}
+                            {{#if (eq injury.type 'trauma')}}[{{localize "TYPES.Item.trauma"}}] {{/if}}
+                            {{#if (eq injury.type 'injury')}}[{{localize "TYPES.Item.injury"}}] {{/if}}
                             {{injury.name}}</strong>
-                        <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type='
-                            injury'}}' data-item-id='{{injury._id}}'>
+                        <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type=(localize (concat "TYPES.Item." injury.type))}}' data-item-id='{{injury._id}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' injury'}}' data-item-id='{{injury._id}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize (concat "TYPES.Item." injury.type))}}' data-item-id='{{injury._id}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -125,7 +124,7 @@
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Ammunition"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='weapon'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.weapon")}}' data-type='weapon'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -137,7 +136,7 @@
                         data-fc-id="weapon{{item._id}}">
                         <div class='item-image'>
                             <a class='rollable' data-roll-type='item'>
-                                <img src='{{item.img}}' title='{{item.name}} - click to expand special rules' width='24'
+                                <img src='{{item.img}}' title='{{localize "ARKHAM_HORROR.TOOLTIPS.ExpandSpecialRules" itemName=item.name}}' width='24'
                                     height='24' />
                             </a>
                         </div>
@@ -147,27 +146,27 @@
                     <div class='item-prop damage-prop'>{{item.system.damage}}</div>
                     <div class='item-prop injury-rating-prop'>{{item.system.injuryRating}}</div>
                     <div class='item-prop range-prop'>
-                        {{#if (eq item.system.range 0)}}Engaged{{else}}{{item.system.range}}{{/if}}
+                        {{#if (eq item.system.range 0)}}{{localize "ARKHAM_HORROR.PROPS.Engaged"}}{{else}}{{item.system.range}}{{/if}}
                     </div>
                     <div class='item-prop'><input type="text" value="{{item.system.ammunition.current}}"
                             data-item-stat="system.ammunition.current" class="item-editable-stat ammo_input"> /
                         {{item.system.ammunition.max}} <span class="weapon-reload-icon" data-item-id='{{item._id}}'
-                            data-action="clickWeaponReload" title="{reload"><i
+                            data-action="clickWeaponReload" title="{{localize "ARKHAM_HORROR.ACTIONS.Reload"}}" aria-label="{{localize "ARKHAM_HORROR.ACTIONS.Reload"}}"><i
                                 class="fa-solid fa-rotate clickable"></i></span></div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.weapon")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.weapon")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
                 </div>
                 <div class="foldable-content" data-fc-id="weapon{{item._id}}">
                     <div>
-                        <strong>Special Rules:</strong>
+                        <strong>{{localize "ARKHAM_HORROR.PROPS.SpecialRules"}}:</strong>
                         {{{item.system.specialRules}}}
                     </div>
                 </div>
@@ -180,11 +179,11 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.ProtectiveEquipment"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='protective_equipment'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.protective_equipment")}}' data-type='protective_equipment'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -204,11 +203,11 @@
                     <div class='item-prop'>{{formatCurrency item.system.cost}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.protective_equipment")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.protective_equipment")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -216,11 +215,11 @@
                 <div class="foldable-content" data-fc-id="protectiveEquipment{{item._id}}">
                     <div class="grid grid-2col">
                         <div>
-                            <strong>Defensive Benefit:</strong>
+                            <strong>{{localize "ARKHAM_HORROR.PROPS.DefensiveBenefit"}}:</strong>
                             {{{item.system.defensiveBenefit}}}
                         </div>
                         <div>
-                            <strong>Special Rules:</strong>
+                            <strong>{{localize "ARKHAM_HORROR.PROPS.SpecialRules"}}:</strong>
                             {{{item.system.specialRules}}}
                         </div>
                     </div>
@@ -234,13 +233,13 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.Spells"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Skill"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Difficulty"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Range"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type='spell'}}' data-type='spell'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.spell")}}' data-type='spell'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -266,11 +265,11 @@
                     <div class='item-prop'>{{item.system.range}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.spell")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -289,12 +288,12 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.UsefulItems"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Uses"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Useful Item'}}' data-type='useful_item'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.useful_item")}}' data-type='useful_item'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -317,18 +316,18 @@
                         {{item.system.uses.max}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
                 </div>
                 <div class="foldable-content" data-fc-id="usefulItem{{item._id}}">
                     <div>
-                        <strong>Special Rules:</strong>
+                        <strong>{{localize "ARKHAM_HORROR.PROPS.SpecialRules"}}:</strong>
                         {{{item.system.specialRules}}}
                     </div>
                 </div>
@@ -341,11 +340,11 @@
         <h5 class="quick-label">{{localize "ARKHAM_HORROR.LABELS.OtherEquipment"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
                 <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Costs"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createOtherEquipment"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.useful_item")}}'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -365,18 +364,18 @@
                     <div class='item-prop'>{{#if item.system.costs}}{{item.system.costs}}{{else}}{{formatCurrency item.system.cost}}{{/if}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
                 </div>
                 <div class="foldable-content" data-fc-id="otherEquipment{{item._id}}">
                     <div>
-                        <strong>Description:</strong>
+                        <strong>{{localize "ARKHAM_HORROR.LABELS.Description"}}:</strong>
                         {{{item.system.description}}}
                     </div>
                 </div>

--- a/templates/reroll-dice-app/dialog.hbs
+++ b/templates/reroll-dice-app/dialog.hbs
@@ -1,8 +1,8 @@
 <form class="arkham-reroll-form">
   <div class="arkham-reroll-meta">
-    <div class="arkham-reroll-meta-row"><strong>Success on:</strong> {{successOn}}+</div>
-    <div class="arkham-reroll-meta-row"><strong>Penalty:</strong> {{penalty}}</div>
-    <div class="arkham-reroll-meta-row"><strong>Result Mod:</strong> {{resultModifier}}</div>
+    <div class="arkham-reroll-meta-row"><strong>{{localize "ARKHAM_HORROR.Dialog.RerollDice.SuccessOn"}}:</strong> {{successOn}}+</div>
+    <div class="arkham-reroll-meta-row"><strong>{{localize "ARKHAM_HORROR.PROPS.Penalty"}}:</strong> {{penalty}}</div>
+    <div class="arkham-reroll-meta-row"><strong>{{localize "ARKHAM_HORROR.PROPS.ResultModifier"}}:</strong> {{resultModifier}}</div>
   </div>
 
   <hr />
@@ -19,9 +19,9 @@
             {{result}}
           </span>
           <span class="arkham-reroll-die-label">
-            {{#if isHorror}}Horror{{else}}Normal{{/if}} — Raw {{rawResult}} → Final {{result}}
-            {{#if isDropped}}(dropped){{/if}}
-            {{#if isForbidden}}(cannot reroll){{/if}}
+            {{#if isHorror}}{{localize "ARKHAM_HORROR.Dialog.RerollDice.DieTypeHorror"}}{{else}}{{localize "ARKHAM_HORROR.Dialog.RerollDice.DieTypeNormal"}}{{/if}} — {{localize "ARKHAM_HORROR.Dialog.RerollDice.Raw"}} {{rawResult}} → {{localize "ARKHAM_HORROR.Dialog.RerollDice.Final"}} {{result}}
+            {{#if isDropped}}({{localize "ARKHAM_HORROR.Dialog.RerollDice.Dropped"}}){{/if}}
+            {{#if isForbidden}}({{localize "ARKHAM_HORROR.Dialog.RerollDice.CannotReroll"}}){{/if}}
           </span>
         </label>
       </div>
@@ -30,7 +30,7 @@
 
   <footer class="form-footer">
     <button type="submit" data-action="clickedReroll">
-      <i class="fa-solid fa-arrow-rotate-right"></i> Reroll Selected
+      <i class="fa-solid fa-arrow-rotate-right"></i> {{localize "ARKHAM_HORROR.Dialog.RerollDice.RerollSelected"}}
     </button>
   </footer>
 </form>

--- a/templates/spend-insight-app/dialog.hbs
+++ b/templates/spend-insight-app/dialog.hbs
@@ -1,6 +1,6 @@
 <form class="roll-dialog-container scrollable">
   <div class="form-group">
-    <label>Spend Insight</label>
+    <label>{{localize "ARKHAM_HORROR.ACTIONS.SpendInsight"}}</label>
     <div class="flexrow">
       <button class="button-dicepool-rolldialog" data-action="clickedDecreaseSpend" {{#if (lte max 1)}}disabled{{/if}}>-</button>
       <input type="number" name="amount" value="{{amount}}" min="1" max="{{max}}" step="1" autofocus /> /
@@ -9,9 +9,9 @@
     </div>
   </div>
 
-  <p class="arkham-horror-hint">Remaining: {{remaining}}/{{limit}}</p>
+  <p class="arkham-horror-hint">{{localize "ARKHAM_HORROR.Dialog.SpendInsight.Remaining" remaining=remaining limit=limit}}</p>
 
   <footer class="dialog-footer">
-    <button type="button" class="roll-button" data-action="clickedSpend"><i class="fa-solid fa-lightbulb"></i> Spend</button>
+    <button type="button" class="roll-button" data-action="clickedSpend"><i class="fa-solid fa-lightbulb"></i> {{localize "ARKHAM_HORROR.Dialog.SpendInsight.Spend"}}</button>
   </footer>
 </form>

--- a/templates/vehicle/parts/vehicle-header.hbs
+++ b/templates/vehicle/parts/vehicle-header.hbs
@@ -9,36 +9,36 @@
         {{!-- Edit Mode Layout --}}
         <div class="title">
             <h1 class="charname"><input name="name" type="text" value="{{actor.name}}"
-                    placeholder="{{localize 'MIST_ENGINE.PLACEHOLDERS.Name'}}" /></h1>
+                    placeholder="{{localize "ARKHAM_HORROR.PROPS.Name"}}" /></h1>
 
         </div>
 
         <div class="dicepool-container grid grid-3col">
 
-            <div class="header-form-group"><label>Damage:</label><input type="number" name="system.damage.current"
+            <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.PROPS.Damage"}}:</label><input type="number" name="system.damage.current"
                     value="{{system.damage.current}}" data-dtype="Number" class="small-input" />
                 / <input type="number" name="system.damage.max" value="{{system.damage.max}}" data-dtype="Number"
                     class="small-input" /></div>
 
-            <div class="header-form-group"><label>Passengers:</label><input type="number"
+            <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.PROPS.Passengers"}}:</label><input type="number"
                     name="system.passengers.current" value="{{system.passengers.current}}" data-dtype="Number"
                     class="small-input" />
                 / <input type="number" name="system.passengers.max" value="{{system.passengers.max}}"
                     data-dtype="Number" class="small-input" /></div>
             
-                        <div class="header-form-group"><label>Fuel:</label><input type="number" name="system.fuel.current"
+                        <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.PROPS.Fuel"}}:</label><input type="number" name="system.fuel.current"
                     value="{{system.fuel.current}}" data-dtype="Number" class="small-input" />
                 / <input type="number" name="system.fuel.max" value="{{system.fuel.max}}" data-dtype="Number"
                     class="small-input" /></div>
         </div>
         <div class="dicepool-container grid grid-3col">
-            <div class="header-form-group"><label>Cost:</label><input type="number" name="system.cost"
+            <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.PROPS.Cost"}}:</label><input type="number" name="system.cost"
                 value="{{system.cost}}" data-dtype="Number" class="large-input" step="0.01" inputmode="decimal" />
             </div>
-            <div class="header-form-group"><label>Max Range:</label><input type="number" name="system.maxRange"
+            <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.PROPS.MaxRange"}}:</label><input type="number" name="system.maxRange"
                     value="{{system.maxRange}}" data-dtype="Number" class="medium-input" />
             </div>
-            <div class="header-form-group"><label>Cargo Capacity:</label><input type="number"
+            <div class="header-form-group"><label>{{localize "ARKHAM_HORROR.PROPS.CargoCapacity"}}:</label><input type="number"
                     name="system.loadCapacity.current" value="{{system.loadCapacity.current}}" data-dtype="Number"
                     class="medium-input" />
                 / <input type="number" name="system.loadCapacity.max" value="{{system.loadCapacity.max}}"

--- a/templates/vehicle/parts/vehicle-main.hbs
+++ b/templates/vehicle/parts/vehicle-main.hbs
@@ -3,14 +3,14 @@
  
     <div class="resource-group">
         <!-- Cargo -->
-        <h5 class="quick-label">Cargo</h5>
+        <h5 class="quick-label">{{localize "ARKHAM_HORROR.VEHICLE.Cargo"}}</h5>
         <ol class='items-list'>
             <li class='item flexrow items-header'>
-                <div class='item-name'>{{localize 'Name'}}</div>
-                <div class='item-prop'>Weight</div>
+                <div class='item-name'>{{localize "ARKHAM_HORROR.PROPS.Name"}}</div>
+                <div class='item-prop'>{{localize "ARKHAM_HORROR.PROPS.Weight"}}</div>
                 <div class='item-controls'>
                     <a class='item-control item-create' data-action="createItem"
-                        title='{{localize "DOCUMENT.Create" type=' Item'}}' data-type='useful_item'>
+                        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.useful_item")}}' data-type='useful_item'>
                         <i class='fas fa-plus'></i>
                     </a>
                 </div>
@@ -29,11 +29,11 @@
                     <div class='item-prop'>{{item.system.weight}}</div>
                     <div class='item-controls'>
                         <a class='item-control item-edit' data-action="editItem"
-                            title='{{localize "DOCUMENT.Update" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-edit'></i>
                         </a>
                         <a class='item-control item-delete' data-action="deleteItem"
-                            title='{{localize "DOCUMENT.Delete" type=' Item'}}'>
+                            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.useful_item")}}'>
                             <i class='fas fa-trash'></i>
                         </a>
                     </div>
@@ -43,7 +43,7 @@
         </ol>
     </div>
     <div class="form-group-rich-editor">
-        <h4>Abilities / Description</h4>
+        <h4>{{localize "ARKHAM_HORROR.VEHICLE.AbilitiesDescription"}}</h4>
         <prose-mirror name="system.specialRules" button="true" editable="{{editable}}" toggled="false"
             value="{{system.specialRules}}">
             {{{specialRulesHTML}}}


### PR DESCRIPTION
This adds localization EVERYWHERE to ALL the things.  We should now have complete coverage of the current codebase.  As long as we maintain on a go-forward we will be good.  We now can control everything from the .json

This doesn't take into account any sort of formatting or anything to account for longer / shorter strings across translations.  This is simply to get everything localized.

2 Notes.
1) I found that it seemed that the usage of "DOCUMENT.Create / DOCUMENT.New" etc. doesn't seem to localize?  I am leaving all of these for now they should be fine to find and fix and are only in tooltips; need to research if Foundry has dropped support for this convention?
2) I have introduced a potential weakness in our localization specifically 1 usage of unescaped localization strings specifically for usage in chat cards: Intentional unescaped localization in chat cards: [roll-result.hbs:15-23] to allow the "Very Difficult" badge to have a <br /> in the localization string.  We should be fine if that specific key stays HTML-only and translator-controlled we just have to avoid ever formatting user-provided values into triple-stash localized strings.  This seemed the easiest way forward for right now, we can reassess once this is fully in as we know where it is and why it is doing what it is doing just this single instance.

Showing Deutch to illustrate scope of these changes across the system.

<img width="899" height="1350" alt="image" src="https://github.com/user-attachments/assets/078b8481-21be-4ea5-a103-b68d007088f4" />

<img width="506" height="692" alt="image" src="https://github.com/user-attachments/assets/d13db78c-0850-4695-8f9e-b7d8c62d4dea" />

<img width="448" height="166" alt="image" src="https://github.com/user-attachments/assets/d95a348f-5db6-4bee-a764-9679f7b91934" />

<img width="975" height="1115" alt="image" src="https://github.com/user-attachments/assets/34fa537e-c0a8-4901-b4e5-bded6486ffd5" />

<img width="975" height="1043" alt="image" src="https://github.com/user-attachments/assets/ca32581b-3c31-4b7f-b01f-0e83001362b5" />

<img width="439" height="1350" alt="image" src="https://github.com/user-attachments/assets/41536b69-d662-4140-9501-332bf39af52b" />

<img width="583" height="698" alt="image" src="https://github.com/user-attachments/assets/d3ed4350-520e-490e-8eb6-bc66b9ecfa35" />
