### PR TITLE
Styling Fix: Personality Traits

### DIFF
--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -648,6 +648,37 @@
   height: 100%;
 }
 
+// Personality trait sheet stacks two editors; the generic 100% height causes overlap.
+// Important: only set display when active so we don't break Foundry's tab hiding.
+.personality-trait-form.active {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.personality-trait-form .form-group-rich-editor > h4 {
+  margin: 0 0 5px;
+}
+
+.personality-trait-form .form-group-rich-editor {
+  height: auto;
+}
+
+// Foundry's ProseMirror markup uses an .editor wrapper; globally we set it to 100% height
+// for single-editor tabs, but here we need it to size to content to avoid overlap.
+.personality-trait-form .editor,
+.personality-trait-form .editor.prosemirror {
+  height: auto;
+}
+
+.personality-trait-form prose-mirror {
+  display: block;
+}
+
+.personality-trait-form prose-mirror .editor-content {
+  min-height: 120px;
+}
+
 .roll-button {
   margin: 5px;
   margin-top: 25px;

--- a/templates/item/item-personality_trait-sheet.hbs
+++ b/templates/item/item-personality_trait-sheet.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.form.id}} {{tabs.form.cssClass}} scrollable" id="form" data-tab="{{tabs.form.id}}"
+<section class="tab {{tabs.form.id}} {{tabs.form.cssClass}} scrollable personality-trait-form" id="form" data-tab="{{tabs.form.id}}"
     data-group="{{tabs.form.group}}">
 
     <div class="form-group-rich-editor">


### PR DESCRIPTION
Small styling fix for personality trait item sheets where the prose mirror fields were over lapping.

Before:
<img width="581" height="227" alt="image" src="https://github.com/user-attachments/assets/c0736dc4-8a23-4f3c-a2f9-ec6326c52d3e" />

After:
<img width="602" height="540" alt="image" src="https://github.com/user-attachments/assets/8c508fa0-c2c8-4e13-b04c-f46f78ce76b9" />
