### PR TITLE
fix issue with roll card breaking chat box on long weapon or spell names

### DIFF
--- a/src/scss/global/_chat.scss
+++ b/src/scss/global/_chat.scss
@@ -18,6 +18,16 @@
     border-bottom: 0;
 }
 
+// Weapon/spell name header rows only: ensure the title area is width-constrained
+// so long item names can ellipsize instead of overflowing the chat card.
+.arkham-roll-header--item-name {
+    overflow: hidden;
+}
+
+.arkham-roll-header--item-name .arkham-roll-heading {
+    flex: 1 1 auto;
+}
+
 .arkham-roll-heading {
     display: flex;
     align-items: center;
@@ -113,6 +123,25 @@
     font-weight: 800;
     letter-spacing: 1.2px;
     text-transform: uppercase;
+    white-space: nowrap;
+}
+
+// Weapon/spell names in chat can be arbitrarily long.
+// Ellipsis is applied to the inner text node because `text-overflow` is unreliable on flex containers.
+.arkham-roll-kind--item-name {
+    max-width: 100%;
+    min-width: 0;
+}
+
+.arkham-roll-kind.arkham-roll-kind--item-name {
+    width: 100%;
+}
+
+.arkham-roll-kind--item-name .arkham-roll-kind__text {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
 }
 

--- a/templates/chat/roll-result.hbs
+++ b/templates/chat/roll-result.hbs
@@ -168,9 +168,9 @@
         </div>
 
         {{#if weaponUsed}}
-            <header class="arkham-roll-header">
+            <header class="arkham-roll-header arkham-roll-header--item-name">
                 <div class="arkham-roll-heading">
-                    <span class="arkham-roll-kind">{{weaponUsed.name}}</span>
+                    <span class="arkham-roll-kind arkham-roll-kind--item-name" title="{{weaponUsed.name}}"><span class="arkham-roll-kind__text">{{weaponUsed.name}}</span></span>
                 </div>
             </header>
             
@@ -194,9 +194,9 @@
         {{/if}}
 
         {{#if spellUsed}}
-            <header class="arkham-roll-header">
+            <header class="arkham-roll-header arkham-roll-header--item-name">
                 <div class="arkham-roll-heading">
-                    <span class="arkham-roll-kind">{{spellUsed.name}}</span>
+                    <span class="arkham-roll-kind arkham-roll-kind--item-name" title="{{spellUsed.name}}"><span class="arkham-roll-kind__text">{{spellUsed.name}}</span></span>
                 </div>
             </header>
             {{#if spellHasSpecialRules}}


### PR DESCRIPTION
When setting up for Comets of Kingsport I noticed that I had a melee weapon book with a super long title on Amanda Sharpe, because our weapon /spell pills were set to no-wrap this broke the bounds and made the chat card unreadable.  This fix creates allows ellpsis overflow with a hover tooltip to read the whole name while maintaining bounding:

Before:

<img width="282" height="505" alt="image" src="https://github.com/user-attachments/assets/12214a75-1624-4bb3-b105-5869e38e9744" />

After:
<img width="458" height="575" alt="image" src="https://github.com/user-attachments/assets/2455abbc-8f3e-4291-aa34-145b92ede880" />
