### PR TITLE
Injury trauma automation!

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -73,7 +73,8 @@
       "ExpandSpecialRules": "{itemName} - klicken, um Spezialregeln zu erweitern",
       "OpenArchetype": "Archetyp öffnen",
       "UnusedXP": "Ungenutzte EP",
-      "TotalXP": "Gesamt-EP"
+      "TotalXP": "Gesamt-EP",
+      "ToggleItemActive": "Aktiv umschalten"
     },
     "TABS": {
       "Description": "Beschreibung",
@@ -124,6 +125,20 @@
       "BonusDiceDelta": "Bonuswürfel (Delta)",
       "ResultModifierDelta": "Ergebnis-Modifikator (Delta)",
       "Remove": "Entfernen"
+    },
+    "INJURY_SHEET": {
+      "Active": "Aktiv",
+      "RollEffectsAutomatic": "Wurf-Effekte (automatische Mali)",
+      "Enabled": "Aktiviert",
+      "AppliesToSkills": "Gilt für Fertigkeiten",
+      "AppliesToRollTypes": "Gilt für Wurftypen",
+      "PenaltyPerDie": "Malus (pro Würfel)",
+      "PenaltyHint": "Wird automatisch als Malus auf passende Würfe angewendet. Doppelte Verletzungen stapeln nicht; alle Instanzen müssen geheilt werden, um den Effekt zu entfernen."
+    },
+    "TRAUMA_SHEET": {
+      "Active": "Aktiv",
+      "TraumaRollModifier": "Erhöht Trauma-Würfe",
+      "TraumaRollModifierHint": "Wenn aktiviert, fügt dieses Trauma zukünftigen Trauma-Würfen +1 hinzu (Verletzungswürfe sind nicht betroffen)."
     },
     "KNACK_USAGE": {
       "passive": "Passiv",
@@ -470,12 +485,32 @@
       },
       "DiceRoll": {
         "Knacks": "Kniffe",
+        "KnacksAffectingRoll": "Kniffe, die für diesen Wurf anwendbar sind ({selected}/{available} ausgewählt)",
         "KnacksHint": "Wähle Kniffe aus, die angewendet werden sollen. Verwendungen werden beim Würfeln ausgegeben.",
         "SelectedEffects": "Ausgewählte Effekte",
+        "OutOfUses": "Keine Verwendungen übrig",
+        "NoRollChanges": "Keine Änderungen",
+        "PreviewBonusDice": "{dice} Bonuswürfel",
+        "PreviewResultModifier": "{mod} Ergebnis-Modifikator",
+        "PreviewAdvantage": "Vorteil",
+        "PreviewDisadvantage": "Nachteil",
+        "PreviewAdvantagePlusDisadvantage": "Vorteil + Nachteil",
+        "PreviewRerollAllowanceOne": "{count} Neuwurf-Würfel",
+        "PreviewRerollAllowanceMany": "{count} Neuwurf-Würfel",
+        "KnackEffectResult": "{mod} Ergebnis",
+        "KnackEffectAdv": "Vorteil",
+        "KnackEffectDisadv": "Nachteil",
+        "KnackEffectAdvPlusDisadv": "Vorteil+Nachteil",
+        "KnackEffectRerollDieOne": "{count} Neuwurf-Würfel",
+        "KnackEffectRerollDieMany": "{count} Neuwurf-Würfel",
         "Tier": "Stufe {tier}",
         "RefreshUses": "Verwendungen erneuern",
         "None": "Keine",
-        "AdvPlusDisadv": "Vorteil + Nachteil"
+        "AdvPlusDisadv": "Vorteil + Nachteil",
+        "InjuriesAffectingRoll": "Verletzungen, die diesen Wurf beeinflussen",
+        "TotalPenalty": "Gesamtmalus",
+        "InjuriesAutoAppliedHint": "Diese Mali werden automatisch von aktiven Verletzungen angewendet (Doppelte stapeln nicht).",
+        "PenaltyMinus": "Malus -{penalty}"
       },
       "SpendInsight": {
         "Remaining": "Verbleibend: {remaining}/{limit}",
@@ -488,7 +523,10 @@
         "Falling": "Fallen",
         "Die": "Würfel",
         "FallingHeightFt": "Fallhöhe (ft)",
-        "Modifier": "Modifikator"
+        "Modifier": "Modifikator",
+        "InjuriesAffectingModifier": "Verletzungen, die diesen Wurf beeinflussen (Modifikator: +{modifier})",
+        "TraumasAffectingModifier": "Traumata, die diesen Wurf beeinflussen (Modifikator: +{modifier})",
+        "AddsModifier": "fügt +{modifier} hinzu"
       },
       "RerollDice": {
         "SuccessOn": "Erfolg bei",

--- a/lang/en.json
+++ b/lang/en.json
@@ -73,7 +73,8 @@
       "ExpandSpecialRules": "{itemName} - click to expand special rules",
       "OpenArchetype": "Open Archetype",
       "UnusedXP": "Unused XP",
-      "TotalXP": "Total XP"
+      "TotalXP": "Total XP",
+      "ToggleItemActive": "Toggle Active"
     },
     "TABS": {
       "Description": "Description",
@@ -124,6 +125,20 @@
       "BonusDiceDelta": "Bonus Dice (delta)",
       "ResultModifierDelta": "Result Modifier (delta)",
       "Remove": "Remove"
+    },
+    "INJURY_SHEET": {
+      "Active": "Active",
+      "RollEffectsAutomatic": "Roll Effects (Automatic Penalties)",
+      "Enabled": "Enabled",
+      "AppliesToSkills": "Applies to Skills",
+      "AppliesToRollTypes": "Applies to Roll Types",
+      "PenaltyPerDie": "Penalty (per die)",
+      "PenaltyHint": "Automatically applies as a penalty on matching rolls. Duplicates of the same injury do not stack; all instances must be healed to remove the effect."
+    },
+    "TRAUMA_SHEET": {
+      "Active": "Active",
+      "TraumaRollModifier": "Adds to Trauma rolls",
+      "TraumaRollModifierHint": "When enabled, this Trauma adds +1 to future Trauma rolls (injury rolls are unaffected)."
     },
     "KNACK_USAGE": {
       "passive": "Passive",
@@ -470,12 +485,32 @@
       },
       "DiceRoll": {
         "Knacks": "Knacks",
+        "KnacksAffectingRoll": "Knacks applicable to this roll ({selected}/{available} selected)",
         "KnacksHint": "Select Knacks to apply. Uses are spent when you roll.",
         "SelectedEffects": "Selected effects",
+        "OutOfUses": "Out of uses",
+        "NoRollChanges": "No roll changes",
+        "PreviewBonusDice": "{dice} bonus dice",
+        "PreviewResultModifier": "{mod} result modifier",
+        "PreviewAdvantage": "Advantage",
+        "PreviewDisadvantage": "Disadvantage",
+        "PreviewAdvantagePlusDisadvantage": "Advantage + Disadvantage",
+        "PreviewRerollAllowanceOne": "{count} reroll allowance die",
+        "PreviewRerollAllowanceMany": "{count} reroll allowance dice",
+        "KnackEffectResult": "{mod} result",
+        "KnackEffectAdv": "Adv",
+        "KnackEffectDisadv": "Disadv",
+        "KnackEffectAdvPlusDisadv": "Adv+Disadv",
+        "KnackEffectRerollDieOne": "{count} reroll die",
+        "KnackEffectRerollDieMany": "{count} reroll dice",
         "Tier": "Tier {tier}",
         "RefreshUses": "Refresh uses",
         "None": "None",
-        "AdvPlusDisadv": "Adv + Disadvantage"
+        "AdvPlusDisadv": "Adv + Disadvantage",
+        "InjuriesAffectingRoll": "Injuries affecting this roll",
+        "TotalPenalty": "Total penalty",
+        "InjuriesAutoAppliedHint": "These penalties are applied automatically from active injuries (duplicates do not stack).",
+        "PenaltyMinus": "Penalty -{penalty}"
       },
       "SpendInsight": {
         "Remaining": "Remaining: {remaining}/{limit}",
@@ -488,7 +523,10 @@
         "Falling": "Falling",
         "Die": "Die",
         "FallingHeightFt": "Falling Height (ft)",
-        "Modifier": "Modifier"
+        "Modifier": "Modifier",
+        "InjuriesAffectingModifier": "Injuries affecting this roll (modifier: +{modifier})",
+        "TraumasAffectingModifier": "Traumas affecting this roll (modifier: +{modifier})",
+        "AddsModifier": "adds +{modifier}"
       },
       "RerollDice": {
         "SuccessOn": "Success on",

--- a/module/data/item-injury.mjs
+++ b/module/data/item-injury.mjs
@@ -6,6 +6,53 @@ export default class ArkhamHorrorInjury extends ArkhamHorrorItemBase {
         const fields = foundry.data.fields;
         const schema = super.defineSchema();
 
+        const requiredInteger = { required: true, nullable: false, integer: true };
+
+        // Allows future automation (e.g., knacks) to temporarily disable an injury without deleting it.
+        schema.active = new fields.BooleanField({ required: true, nullable: false, initial: true });
+
+        // Roll effects: automatic penalties applied to matching skill rolls.
+        schema.rollEffects = new fields.SchemaField({
+            enabled: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+
+            skillKeys: new fields.ArrayField(
+                new fields.StringField({
+                    required: true,
+                    nullable: false,
+                    choices: [
+                        "any",
+                        "agility",
+                        "athletics",
+                        "wits",
+                        "presence",
+                        "intuition",
+                        "knowledge",
+                        "resolve",
+                        "meleeCombat",
+                        "rangedCombat",
+                        "lore",
+                    ],
+                }),
+                { initial: ["any"] }
+            ),
+
+            rollKinds: new fields.ArrayField(
+                new fields.StringField({
+                    required: true,
+                    nullable: false,
+                    choices: ["any", "complex", "reaction", "tome-understand", "tome-attune"],
+                }),
+                { initial: ["any"] }
+            ),
+
+            modifier: new fields.SchemaField({
+                // Penalty is a per-die face reduction handled by the roll engine.
+                penalty: new fields.NumberField({ ...requiredInteger, initial: 0, min: 0 }),
+            }),
+        });
+
         return schema;
     }
 }
+
+ 

--- a/module/data/item-trauma.mjs
+++ b/module/data/item-trauma.mjs
@@ -6,6 +6,16 @@ export default class ArkhamHorrorTrauma extends ArkhamHorrorItemBase {
         const fields = foundry.data.fields;
         const schema = super.defineSchema();
 
+        // Allows future automation (e.g., knacks) to temporarily disable a trauma without deleting it.
+        schema.active = new fields.BooleanField({ required: true, nullable: false, initial: true });
+
+        // Simple toggle: this trauma contributes +1 to future Trauma roll modifiers.
+        schema.traumaRollModifier = new fields.SchemaField({
+            enabled: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+        });
+
         return schema;
     }
 }
+
+ 

--- a/module/helpers/injuries.mjs
+++ b/module/helpers/injuries.mjs
@@ -1,0 +1,189 @@
+// Injury/Trauma helper logic
+// - Injury roll effects apply to skill rolls (DiceRollApp) as automatic penalties.
+// - Injury roll (injury/trauma dialog) modifier is based on TOTAL injuries (instances).
+// - Trauma roll modifier is based on enabled trauma flags.
+
+const SYSTEM_ID = "arkham-horror-rpg-fvtt";
+
+const CANONICAL_SKILL_KEYS = [
+  "agility",
+  "athletics",
+  "wits",
+  "presence",
+  "intuition",
+  "knowledge",
+  "resolve",
+  "meleeCombat",
+  "rangedCombat",
+  "lore",
+];
+
+function normalizeSkillKey(key) {
+  const raw = String(key ?? "").trim();
+  if (!raw) return "";
+  const rawLower = raw.toLowerCase();
+  const match = CANONICAL_SKILL_KEYS.find(k => k.toLowerCase() === rawLower);
+  return match ?? raw;
+}
+
+function normalizeRollKind(kind) {
+  const k = String(kind ?? "complex");
+  return k || "complex";
+}
+
+function isActiveItem(item) {
+  // Backwards compatibility: legacy injuries/traumas may not have `system.active` yet.
+  const v = item?.system?.active;
+  return v === undefined ? true : Boolean(v);
+}
+
+function itemIdentityKey(item) {
+  const sourceId = String(item?.flags?.core?.sourceId ?? "").trim();
+  if (sourceId) return `source:${sourceId}`;
+
+  // Fallback to name (best-effort). Not perfect, but stable for world documents.
+  const name = String(item?.name ?? "").trim().toLowerCase();
+  return `name:${name}`;
+}
+
+function groupByIdentity(items) {
+  const map = new Map();
+  for (const item of items) {
+    const key = itemIdentityKey(item);
+    const arr = map.get(key) ?? [];
+    arr.push(item);
+    map.set(key, arr);
+  }
+  return map;
+}
+
+function rollEffectAppliesToSkillRoll({ injury, rollState }) {
+  const re = injury?.system?.rollEffects;
+  if (!re?.enabled) return false;
+  if (!isActiveItem(injury)) return false;
+
+  const skillKey = normalizeSkillKey(rollState?.skillKey);
+  const rollKind = normalizeRollKind(rollState?.rollKind);
+
+  const skills = Array.isArray(re.skillKeys)
+    ? re.skillKeys.map(normalizeSkillKey).filter(Boolean)
+    : ["any"];
+  const kinds = Array.isArray(re.rollKinds)
+    ? re.rollKinds.map(String).filter(Boolean)
+    : ["any"];
+
+  const skillOk = skills.includes("any") || skills.includes(skillKey);
+
+  // Tome rolls behave like complex skill rolls; treat as aliases.
+  const kindAliases = rollKind.startsWith("tome-") ? [rollKind, "complex"] : [rollKind];
+  const kindOk = kinds.includes("any") || kindAliases.some(k => kinds.includes(k));
+
+  return skillOk && kindOk;
+}
+
+function getInjuryPenaltyValue(injury) {
+  const n = Number(injury?.system?.rollEffects?.modifier?.penalty ?? 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.trunc(n));
+}
+
+export function getActiveInjuries(actor) {
+  const items = actor?.items?.contents ?? [];
+  return items.filter(i => i?.type === "injury" && isActiveItem(i));
+}
+
+export function getActiveTraumas(actor) {
+  const items = actor?.items?.contents ?? [];
+  return items.filter(i => i?.type === "trauma" && isActiveItem(i));
+}
+
+export function getTotalInjuryCount(actor) {
+  return getActiveInjuries(actor).length;
+}
+
+export function getInjuryCountSummary(actor) {
+  const injuries = getActiveInjuries(actor);
+  const grouped = groupByIdentity(injuries);
+
+  const entries = [];
+  for (const [, group] of grouped.entries()) {
+    if (!group?.length) continue;
+    const name = String(group[0]?.name ?? "");
+    entries.push({ name, count: group.length });
+  }
+
+  // stable ordering
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    total: injuries.length,
+    entries,
+    hasAny: entries.length > 0,
+  };
+}
+
+/**
+ * Compute injury penalties for a skill roll.
+ *
+ * - Groups injuries by identity so duplicates do NOT stack.
+ * - If any instance in the identity group has enabled rollEffects that apply to this roll,
+ *   the group contributes its penalty ONCE.
+ * - If multiple enabled instances in the group apply, we take the maximum penalty (non-stacking).
+ */
+export function getInjuryImpactForSkillRoll({ actor, rollState } = {}) {
+  const injuries = getActiveInjuries(actor);
+  const grouped = groupByIdentity(injuries);
+
+  const entries = [];
+  let totalPenalty = 0;
+
+  for (const [, group] of grouped.entries()) {
+    if (!group?.length) continue;
+
+    const matching = group.filter(i => rollEffectAppliesToSkillRoll({ injury: i, rollState }));
+    if (matching.length === 0) continue;
+
+    const penalty = Math.max(...matching.map(getInjuryPenaltyValue));
+    if (penalty <= 0) continue;
+
+    const name = String(group[0]?.name ?? "");
+    totalPenalty += penalty;
+    entries.push({ name, count: group.length, penalty });
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    penalty: totalPenalty,
+    entries,
+    count: entries.length,
+    hasAny: entries.length > 0,
+  };
+}
+
+export function getTraumaRollModifierSummary(actor) {
+  const traumas = getActiveTraumas(actor);
+
+  const enabled = traumas.filter(t => Boolean(t?.system?.traumaRollModifier?.enabled));
+  const grouped = groupByIdentity(enabled);
+
+  const entries = [];
+  for (const [, group] of grouped.entries()) {
+    if (!group?.length) continue;
+    const name = String(group[0]?.name ?? "");
+    entries.push({ name, count: group.length, modifier: group.length });
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  const modifier = enabled.length;
+  return {
+    modifier,
+    entries,
+    total: enabled.length,
+    hasAny: entries.length > 0,
+  };
+}
+
+// Reserved for future: system flags should use SYSTEM_ID if we need to store derived state.
+export { SYSTEM_ID };

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -89,6 +89,7 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
             createItem: this.#handleCreateItem,
             createOtherEquipment: this.#handleCreateOtherEquipment,
             deleteItem: this.#handleDeleteItem,
+            toggleItemActive: this.#handleToggleItemActive,
             toggleFoldableContent: this.#handleToggleFoldableContent,
             openActorArchetype: this.#handleOpenActorArchetype,
             clickSkill: this.#handleSkillClicked,
@@ -610,6 +611,21 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
         });
     }
 
+    static async #handleToggleItemActive(event, target) {
+        event.preventDefault();
+        const clickTarget = target instanceof HTMLElement ? target : target?.[0];
+        const itemId = clickTarget?.dataset?.itemId;
+        if (!itemId) return;
+
+        const item = this.actor?.items?.get?.(itemId);
+        if (!item) return;
+
+        // Backwards compatibility: if system.active is missing, treat as active.
+        const current = item.system?.active;
+        const isActive = current === undefined ? true : Boolean(current);
+        await item.update({ 'system.active': !isActive });
+    }
+
     static async #handleOpenActorArchetype(event, target) {
         event.preventDefault();
         await this.openActorArchetype(event, target);
@@ -711,7 +727,6 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
         InjuryTraumaRollApp.getInstance({
             actor: this.actor,
             rollKind: "injury",
-            modifier: 0,
             rollSource: "strain",
         }).render(true);
     }
@@ -754,7 +769,7 @@ export class ArkhamHorrorActorSheet extends HandlebarsApplicationMixin(ActorShee
 
     static async #handleClickedInjuryTraumaRoll(event, target) {
         event.preventDefault();
-        InjuryTraumaRollApp.getInstance({ actor: this.actor, rollKind: "injury", modifier: 0 }).render(true);
+        InjuryTraumaRollApp.getInstance({ actor: this.actor, rollKind: "injury" }).render(true);
     }
 
     static async #handleClickedSpendInsight(event, _target) {

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -100,13 +100,18 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
 
     async addKnackRollEffectKey(event, target) {
         event.preventDefault()
-        if (this.document.type !== 'knack') return
+        if (this.document.type !== 'knack' && this.document.type !== 'injury') return
         if (!this.isEditable) return
 
         const group = String(target?.dataset?.group ?? '')
         if (!group) return
 
-        const selectName = group === 'skillKeys' ? '_knackSkillKey' : group === 'rollKinds' ? '_knackRollKind' : null
+        const type = String(this.document.type ?? '')
+        const selectName = group === 'skillKeys'
+            ? (type === 'injury' ? '_injurySkillKey' : '_knackSkillKey')
+            : group === 'rollKinds'
+                ? (type === 'injury' ? '_injuryRollKind' : '_knackRollKind')
+                : null
         if (!selectName) return
 
         const select = this.element?.querySelector?.(`select[name="${selectName}"]`)
@@ -132,7 +137,7 @@ export class ArkhamHorrorItemSheet extends HandlebarsApplicationMixin(ItemSheetV
 
     async removeKnackRollEffectKey(event, target) {
         event.preventDefault()
-        if (this.document.type !== 'knack') return
+        if (this.document.type !== 'knack' && this.document.type !== 'injury') return
         if (!this.isEditable) return
 
         const group = String(target?.dataset?.group ?? '')

--- a/module/sheets/npc-sheet.mjs
+++ b/module/sheets/npc-sheet.mjs
@@ -27,6 +27,7 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
             createWeakness: this.#handleCreateWeakness,
             createOtherEquipment: this.#handleCreateOtherEquipment,
             deleteItem: this.#handleDeleteItem,
+            toggleItemActive: this.#handleToggleItemActive,
             toggleFoldableContent: this.#handleToggleFoldableContent,
             clickSkill: this.#handleSkillClicked,
             clickSkillReaction: this.#handleSkillReactionClicked,
@@ -232,7 +233,7 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
 
     static async #handleClickedInjuryTraumaRoll(event, target) {
         event.preventDefault();
-        InjuryTraumaRollApp.getInstance({ actor: this.actor, rollKind: "injury", modifier: 0 }).render(true);
+        InjuryTraumaRollApp.getInstance({ actor: this.actor, rollKind: "injury" }).render(true);
     }
 
     static async #handleEditItem(event, target) {
@@ -369,6 +370,21 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         });
     }
 
+    static async #handleToggleItemActive(event, target) {
+        event.preventDefault();
+        const clickTarget = target instanceof HTMLElement ? target : target?.[0];
+        const itemId = clickTarget?.dataset?.itemId;
+        if (!itemId) return;
+
+        const item = this.actor?.items?.get?.(itemId);
+        if (!item) return;
+
+        // Backwards compatibility: if system.active is missing, treat as active.
+        const current = item.system?.active;
+        const isActive = current === undefined ? true : Boolean(current);
+        await item.update({ 'system.active': !isActive });
+    }
+
     static async #handleSkillClicked(event, target) {
         event.preventDefault();
         const skillKey = target.dataset.skillKey;        
@@ -450,7 +466,6 @@ export class ArkhamHorrorNpcSheet extends HandlebarsApplicationMixin(ActorSheetV
         InjuryTraumaRollApp.getInstance({
             actor: this.actor,
             rollKind: "injury",
-            modifier: 0,
             rollSource: "strain",
         }).render(true);
     }

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -238,6 +238,117 @@
     margin-bottom: 6px;
   }
 
+  .arkham-roll-details {
+    display: block;
+    box-sizing: border-box;
+    width: calc(100% - 10px);
+    margin: 6px 5px;
+  }
+
+  .arkham-roll-details-body > .notes {
+    margin: 0;
+    font-size: 11px;
+    opacity: 0.85;
+    line-height: 1.2;
+  }
+
+  .arkham-injury-impact-list {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+    display: grid;
+    gap: 4px;
+    font-size: 0.95em;
+  }
+
+  .arkham-injury-impact-list li {
+    padding: 2px 6px;
+    border-left: 3px solid rgba(114, 42, 28, 0.35);
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 3px;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
+  }
+
+  .arkham-knack-impact-item {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "main refresh"
+      "effect effect"
+      "meta meta";
+    gap: 2px 8px;
+    align-items: start;
+  }
+
+  .arkham-knack-impact-main {
+    grid-area: main;
+    display: inline-flex;
+    gap: 6px;
+    align-items: start;
+    min-width: 0;
+  }
+
+  .arkham-knack-impact-main input[type="checkbox"] {
+    margin: 2px 0 0 0;
+  }
+
+  .arkham-knack-impact-name {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .arkham-knack-impact-effect {
+    grid-area: effect;
+    font-size: 0.9em;
+    opacity: 0.9;
+    text-align: left;
+    padding-left: 22px;
+    overflow-wrap: anywhere;
+  }
+
+  .arkham-knack-impact-meta {
+    grid-area: meta;
+    display: block;
+    font-size: 0.85em;
+    opacity: 0.85;
+    padding-left: 22px;
+  }
+
+  .arkham-knack-impact-item .knack-refresh {
+    grid-area: refresh;
+    justify-self: end;
+    align-self: center;
+  }
+
+  .arkham-knack-impact-item.is-checked {
+    background: rgba(114, 42, 28, 0.10);
+    border-left-color: rgba(114, 42, 28, 0.6);
+  }
+
+  .arkham-knack-impact-item.is-disabled {
+    opacity: 0.75;
+  }
+
+  .knack-preview {
+    margin: 0 0 6px 0;
+    padding: 4px 6px;
+    background: rgba(255, 255, 255, 0.14);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 4px;
+  }
+
+  .knack-preview__title {
+    margin-bottom: 2px;
+    color: rgba(114, 42, 28, 1);
+    font-family: $font-primary;
+    font-size: 0.95em;
+  }
+
+  .arkham-knack-preview-list {
+    font-size: 0.92em;
+  }
+
   .form-group.knack-choices {
     flex-wrap: wrap;
     align-items: stretch;

--- a/templates/actor/parts/character-injuries.hbs
+++ b/templates/actor/parts/character-injuries.hbs
@@ -12,6 +12,9 @@
                 {{#if (eq injury.type 'trauma')}}[{{localize "TYPES.Item.trauma"}}] {{/if}}
                 {{#if (eq injury.type 'injury')}}[{{localize "TYPES.Item.injury"}}] {{/if}}
                 {{injury.name}}</strong>
+            <a class='item-control item-toggle-active' data-action="toggleItemActive" title="{{localize 'ARKHAM_HORROR.TOOLTIPS.ToggleItemActive'}}" aria-label="{{localize 'ARKHAM_HORROR.TOOLTIPS.ToggleItemActive'}}" data-item-id='{{injury._id}}'>
+                <i class='fa-solid {{#unless (eq injury.system.active false)}}fa-toggle-on{{else}}fa-toggle-off{{/unless}}'></i>
+            </a>
             <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type=(localize (concat "TYPES.Item." injury.type))}}' aria-label='{{localize "DOCUMENT.Update" type=(localize (concat "TYPES.Item." injury.type))}}' data-item-id='{{injury._id}}'>
                 <i class='fas fa-edit'></i>
             </a>

--- a/templates/dice-roll-app/dialog.hbs
+++ b/templates/dice-roll-app/dialog.hbs
@@ -73,50 +73,68 @@
     <footer class="dialog-footer dialog-footer--primary">
         <button type="button" class="roll-button" data-action="clickedRoll"><i class="fa-solid fa-dice"></i> {{localize "ARKHAM_HORROR.ACTIONS.Roll"}}</button>
     </footer>
+    
+    {{#if injuryImpact.hasAny}}
+    <details class="arkham-roll-details">
+        <summary class="arkham-roll-details-summary">
+            {{localize "ARKHAM_HORROR.Dialog.DiceRoll.InjuriesAffectingRoll"}}: -{{injuryImpact.penalty}} ({{localize "ARKHAM_HORROR.Dialog.DiceRoll.TotalPenalty"}}: {{totalPenalty}})
+        </summary>
+        <div class="arkham-roll-details-body">
+            <div class="notes">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.InjuriesAutoAppliedHint"}}</div>
+            <ul class="arkham-injury-impact-list">
+                {{#each injuryImpact.entries as |e|}}
+                    <li>{{e.name}} (x{{e.count}}) — {{localize "ARKHAM_HORROR.Dialog.DiceRoll.PenaltyMinus" penalty=e.penalty}}</li>
+                {{/each}}
+            </ul>
+        </div>
+    </details>
+    {{/if}}
 
     {{#if knackChoices}}
-    <hr />
-    <div class="form-group knack-choices">
-        <label>{{localize "ARKHAM_HORROR.LABELS.Knacks"}}</label>
-        <div class="notes">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.KnacksHint"}}</div>
+    <details class="arkham-roll-details" data-role="knacksDetails">
+        <summary class="arkham-roll-details-summary">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.KnacksAffectingRoll" selected=knackSummary.selected available=knackSummary.available}}</summary>
+        <div class="arkham-roll-details-body">
+            <div class="notes">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.KnacksHint"}}</div>
 
-        {{#if knackPreview.hasSelection}}
-        <div class="knack-preview">
-            <div class="knack-preview__title">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.SelectedEffects"}}</div>
-            <div class="knack-preview__text">{{knackPreview.text}}</div>
-        </div>
-        {{/if}}
-
-        {{#each knackChoices as |k|}}
-        <div class="flexrow knack-choice-row {{#if k.checked}}is-checked{{/if}} {{#if k.disabled}}is-disabled{{/if}}">
-            <input type="checkbox" name="selectedKnackIds" value="{{k.id}}" {{#if k.checked}}checked{{/if}} {{#if k.disabled}}disabled{{/if}}>
-            <span>
-                {{localize "ARKHAM_HORROR.Dialog.DiceRoll.Tier" tier=k.tier}} - {{k.name}}
-                {{#if k.effect}}
-                    <span class="knack-effect">— {{k.effect.text}}</span>
-                {{/if}}
-                {{#if k.availabilityNote}}
-                    <span class="knack-availability">— {{k.availabilityNote}}</span>
-                {{/if}}
-                <small class="notes">
-                    ({{k.frequency}}
-                    {{#if (eq k.frequency "passive")}}
-                    {{else}}
-                        {{#if (eq k.frequency "unlimited")}}
-                        {{else}}
-                            : {{k.remaining}}/{{k.max}}
-                        {{/if}}
-                    {{/if}})
-                </small>
-            </span>
-
-            {{#if k.showRefresh}}
-            <button type="button" class="knack-refresh" data-action="refreshKnackUses" data-item-id="{{k.id}}" title="{{localize "ARKHAM_HORROR.Dialog.DiceRoll.RefreshUses"}}" aria-label="{{localize "ARKHAM_HORROR.Dialog.DiceRoll.RefreshUses"}}">
-                <i class="fas fa-rotate-right"></i>
-            </button>
+            {{#if knackPreview.hasSelection}}
+            <div class="knack-preview">
+                <div class="knack-preview__title">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.SelectedEffects"}}</div>
+                <ul class="arkham-injury-impact-list arkham-knack-preview-list">
+                    {{#each knackPreview.entries as |t|}}
+                        <li>{{t}}</li>
+                    {{/each}}
+                </ul>
+            </div>
             {{/if}}
+
+            <ul class="arkham-injury-impact-list arkham-knack-impact-list">
+                {{#each knackChoices as |k|}}
+                <li class="arkham-knack-impact-item {{#if k.checked}}is-checked{{/if}} {{#if k.disabled}}is-disabled{{/if}}">
+                    <label class="arkham-knack-impact-main">
+                        <input type="checkbox" name="selectedKnackIds" value="{{k.id}}" {{#if k.checked}}checked{{/if}} {{#if k.disabled}}disabled{{/if}}>
+                        <span class="arkham-knack-impact-name">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.Tier" tier=k.tier}} - {{k.name}}</span>
+                    </label>
+
+                    {{#if k.effect}}
+                    <span class="arkham-knack-impact-effect">{{k.effect.text}}</span>
+                    {{/if}}
+
+                    <small class="arkham-knack-impact-meta">
+                        ({{k.useText}}){{#if k.availabilityNote}} — {{k.availabilityNote}}{{/if}}
+                    </small>
+
+                    {{#if k.showRefresh}}
+                    <button type="button" class="knack-refresh" data-action="refreshKnackUses" data-item-id="{{k.id}}" title="{{localize "ARKHAM_HORROR.Dialog.DiceRoll.RefreshUses"}}" aria-label="{{localize "ARKHAM_HORROR.Dialog.DiceRoll.RefreshUses"}}">
+                        <i class="fas fa-rotate-right"></i>
+                    </button>
+                    {{/if}}
+                </li>
+                {{/each}}
+            </ul>
         </div>
-        {{/each}}
-    </div>
+    </details>
     {{/if}}
+
 </form>
+
+ 

--- a/templates/injury-trauma-roll-app/dialog.hbs
+++ b/templates/injury-trauma-roll-app/dialog.hbs
@@ -28,10 +28,36 @@
     <input type="number" name="fallingHeightFt" value="{{fallingHeightFt}}" min="10" step="1" />
   </div>
 
-  <div class="form-group">
+  <div class="form-group" data-roll-mode="standard">
     <label>{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.Modifier"}}</label>
     <input type="number" name="modifier" value="{{modifier}}" step="1" />
   </div>
+
+  {{#if injurySummary.hasAny}}
+    <details class="arkham-roll-details" data-role="injuryContrib">
+      <summary class="arkham-roll-details-summary">{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.InjuriesAffectingModifier" modifier=injuryAutoModifier}}</summary>
+      <div class="arkham-roll-details-body">
+        <ul class="arkham-injury-impact-list">
+          {{#each injurySummary.entries as |e|}}
+            <li>{{e.name}} (x{{e.count}})</li>
+          {{/each}}
+        </ul>
+      </div>
+    </details>
+  {{/if}}
+
+  {{#if traumaSummary.hasAny}}
+    <details class="arkham-roll-details" data-role="traumaContrib">
+      <summary class="arkham-roll-details-summary">{{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.TraumasAffectingModifier" modifier=traumaAutoModifier}}</summary>
+      <div class="arkham-roll-details-body">
+        <ul class="arkham-injury-impact-list">
+          {{#each traumaSummary.entries as |e|}}
+            <li>{{e.name}} (x{{e.count}}) — {{localize "ARKHAM_HORROR.Dialog.InjuryTrauma.AddsModifier" modifier=e.modifier}}</li>
+          {{/each}}
+        </ul>
+      </div>
+    </details>
+  {{/if}}
 
   <input type="hidden" name="rollSource" value="{{rollSource}}" />
 

--- a/templates/item/item-injury-sheet.hbs
+++ b/templates/item/item-injury-sheet.hbs
@@ -1,3 +1,99 @@
 <section class="tab {{tabs.form.id}} {{tabs.form.cssClass}} scrollable" id="form" data-tab="{{tabs.form.id}}"
     data-group="{{tabs.form.group}}">
+
+    <div class="resource-group-styled knack-sheet">
+
+        <div class="form-group">
+            <label class="styled-label">{{localize "ARKHAM_HORROR.INJURY_SHEET.Active"}}</label>
+            <input type="checkbox" name="system.active" {{#if system.active}}checked{{/if}}>
+        </div>
+
+        <hr />
+
+        <h5 class="quick-label">{{localize "ARKHAM_HORROR.INJURY_SHEET.RollEffectsAutomatic"}}</h5>
+        <div class="form-group">
+            <label class="styled-label">{{localize "ARKHAM_HORROR.INJURY_SHEET.Enabled"}}</label>
+            <input type="checkbox" name="system.rollEffects.enabled" {{#if system.rollEffects.enabled}}checked{{/if}}>
+        </div>
+
+        <div class="form-group">
+            <label class="styled-label">{{localize "ARKHAM_HORROR.INJURY_SHEET.AppliesToSkills"}}</label>
+            <div class="knack-picker" data-group="skillKeys">
+                <div class="knack-picker__controls">
+                    <select class="knack-picker__select" name="_injurySkillKey">
+                        <option value="any">{{localize "ARKHAM_HORROR.KNACK_SHEET.Any"}}</option>
+                        <option value="agility">{{localize "ARKHAM_HORROR.SKILL.agility"}}</option>
+                        <option value="athletics">{{localize "ARKHAM_HORROR.SKILL.athletics"}}</option>
+                        <option value="wits">{{localize "ARKHAM_HORROR.SKILL.wits"}}</option>
+                        <option value="presence">{{localize "ARKHAM_HORROR.SKILL.presence"}}</option>
+                        <option value="intuition">{{localize "ARKHAM_HORROR.SKILL.intuition"}}</option>
+                        <option value="knowledge">{{localize "ARKHAM_HORROR.SKILL.knowledge"}}</option>
+                        <option value="resolve">{{localize "ARKHAM_HORROR.SKILL.resolve"}}</option>
+                        <option value="meleeCombat">{{localize "ARKHAM_HORROR.SKILL.meleeCombat"}}</option>
+                        <option value="rangedCombat">{{localize "ARKHAM_HORROR.SKILL.rangedCombat"}}</option>
+                        <option value="lore">{{localize "ARKHAM_HORROR.SKILL.lore"}}</option>
+                    </select>
+                    <button type="button" class="knack-picker__add" data-action="addKnackRollEffectKey" data-group="skillKeys">+</button>
+                </div>
+                <div class="knack-picker__selected" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.SelectedSkills"}}">
+                    {{#each system.rollEffects.skillKeys as |k|}}
+                        <span class="knack-pill" data-value="{{k}}">
+                            {{#if (eq k "any")}}
+                                {{localize "ARKHAM_HORROR.KNACK_SHEET.Any"}}
+                            {{else}}
+                                {{localize (concat "ARKHAM_HORROR.SKILL." k)}}
+                            {{/if}}
+                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="skillKeys" data-value="{{k}}" title="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}">
+                                <i class="fas fa-times"></i>
+                            </a>
+                        </span>
+                    {{/each}}
+                </div>
+                <div class="notes">{{localize "ARKHAM_HORROR.KNACK_SHEET.AnyOverrides"}}</div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="styled-label">{{localize "ARKHAM_HORROR.INJURY_SHEET.AppliesToRollTypes"}}</label>
+            <div class="knack-picker" data-group="rollKinds">
+                <div class="knack-picker__controls">
+                    <select class="knack-picker__select" name="_injuryRollKind">
+                        <option value="any">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Any"}}</option>
+                        <option value="complex">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Complex"}}</option>
+                        <option value="reaction">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Reaction"}}</option>
+                        <option value="tome-understand">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.TomeUnderstand"}}</option>
+                        <option value="tome-attune">{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.TomeAttune"}}</option>
+                    </select>
+                    <button type="button" class="knack-picker__add" data-action="addKnackRollEffectKey" data-group="rollKinds">+</button>
+                </div>
+                <div class="knack-picker__selected" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.SelectedRollTypes"}}">
+                    {{#each system.rollEffects.rollKinds as |k|}}
+                        <span class="knack-pill" data-value="{{k}}">
+                            {{#if (eq k "any")}}
+                                {{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Any"}}
+                            {{else}}
+                                {{#if (eq k "complex")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Complex"}}{{/if}}
+                                {{#if (eq k "reaction")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.Reaction"}}{{/if}}
+                                {{#if (eq k "tome-understand")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.TomeUnderstand"}}{{/if}}
+                                {{#if (eq k "tome-attune")}}{{localize "ARKHAM_HORROR.KNACK_SHEET.RollKind.TomeAttune"}}{{/if}}
+                            {{/if}}
+                            <a class="knack-pill__remove" data-action="removeKnackRollEffectKey" data-group="rollKinds" data-value="{{k}}" title="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}" aria-label="{{localize "ARKHAM_HORROR.KNACK_SHEET.Remove"}}">
+                                <i class="fas fa-times"></i>
+                            </a>
+                        </span>
+                    {{/each}}
+                </div>
+                <div class="notes">{{localize "ARKHAM_HORROR.KNACK_SHEET.AnyOverrides"}}</div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="styled-label">{{localize "ARKHAM_HORROR.INJURY_SHEET.PenaltyPerDie"}}</label>
+            <input type="number" name="system.rollEffects.modifier.penalty" value="{{system.rollEffects.modifier.penalty}}" min="0" step="1">
+        </div>
+        <div class="notes">{{localize "ARKHAM_HORROR.INJURY_SHEET.PenaltyHint"}}</div>
+
+    </div>
 </section>
+
+ 

--- a/templates/item/item-trauma-sheet.hbs
+++ b/templates/item/item-trauma-sheet.hbs
@@ -1,3 +1,20 @@
 <section class="tab {{tabs.form.id}} {{tabs.form.cssClass}} scrollable" id="form" data-tab="{{tabs.form.id}}"
     data-group="{{tabs.form.group}}">
+
+    <div class="resource-group-styled">
+        <div class="form-group">
+            <label class="styled-label">{{localize "ARKHAM_HORROR.TRAUMA_SHEET.Active"}}</label>
+            <input type="checkbox" name="system.active" {{#if system.active}}checked{{/if}}>
+        </div>
+
+        <hr />
+
+        <div class="form-group">
+            <label class="styled-label">{{localize "ARKHAM_HORROR.TRAUMA_SHEET.TraumaRollModifier"}}</label>
+            <input type="checkbox" name="system.traumaRollModifier.enabled" {{#if system.traumaRollModifier.enabled}}checked{{/if}}>
+        </div>
+        <div class="notes">{{localize "ARKHAM_HORROR.TRAUMA_SHEET.TraumaRollModifierHint"}}</div>
+    </div>
 </section>
+
+ 

--- a/templates/npc/parts/npc-main.hbs
+++ b/templates/npc/parts/npc-main.hbs
@@ -94,6 +94,9 @@
                             {{#if (eq injury.type 'trauma')}}[{{localize "TYPES.Item.trauma"}}] {{/if}}
                             {{#if (eq injury.type 'injury')}}[{{localize "TYPES.Item.injury"}}] {{/if}}
                             {{injury.name}}</strong>
+                        <a class='item-control item-toggle-active' data-action="toggleItemActive" title="{{localize 'ARKHAM_HORROR.TOOLTIPS.ToggleItemActive'}}" aria-label="{{localize 'ARKHAM_HORROR.TOOLTIPS.ToggleItemActive'}}" data-item-id='{{injury._id}}'>
+                            <i class='fa-solid {{#unless (eq injury.system.active false)}}fa-toggle-on{{else}}fa-toggle-off{{/unless}}'></i>
+                        </a>
                         <a class='item-control item-edit' data-action="editItem" title='{{localize "DOCUMENT.Update" type=(localize (concat "TYPES.Item." injury.type))}}' data-item-id='{{injury._id}}'>
                             <i class='fas fa-edit'></i>
                         </a>


### PR DESCRIPTION
This PR now implements basic roll automation for injuries and traumas following current rules standards, it is fully backwards compatible if it is not used and so this automation feature is an optional upgrade for GMs and users.  

We expose a similar function "Roll Effects" on the injury item that allows for specifying which types of rolls and skills the penalty should be applied to, we also have a Trauma simple boolean that only impacts future trauma rolls.

We then add the ability to "turn on and off" traumas and injuries on the actor sheet since certain knacks allow temporary removal of negative injury and trauma effects.

We also did a small formatting fix for knacks on the dice roll app as well to get them a little better looking, still more to do here.

Item setup:
<img width="928" height="847" alt="image" src="https://github.com/user-attachments/assets/5b68eefa-8b1a-48d3-89fb-18e80105f423" />

<img width="913" height="531" alt="image" src="https://github.com/user-attachments/assets/67f4b4d7-68f0-4b6d-9af5-d6b183d90b2c" />

Showing the dice roll app showing an expandable list that contains the injuries we keep Unique count per the rules based on either the sourceID of the injury or the lowercase name, in this example 2 are from compendium one is from world so even though they are duplicate in world and on character from different sources they still just count as -1 penalty and 3 instances (total count does affect injury rolls though)

<img width="975" height="545" alt="image" src="https://github.com/user-attachments/assets/51e25019-cb7f-4246-9273-e3db44cfc5d6" />

<img width="427" height="514" alt="image" src="https://github.com/user-attachments/assets/6fbeb4bc-5b15-4063-979e-dd015c924d11" />

<img width="542" height="583" alt="image" src="https://github.com/user-attachments/assets/85887a13-7fcd-4707-b540-098b50992f75" />

<img width="444" height="458" alt="image" src="https://github.com/user-attachments/assets/7d597bd0-9c74-42f1-8dfa-1eae320065f7" />

Showing Trauma rolls from same character
<img width="538" height="573" alt="image" src="https://github.com/user-attachments/assets/f78eeb78-dda6-4ccb-b983-d1c03dfedd94" />

<img width="448" height="475" alt="image" src="https://github.com/user-attachments/assets/d387ebd1-e252-4f45-8d35-33c4fc883d68" />

Showing that it doesn't modify a roll if set to inactive on a character sheet:
<img width="975" height="969" alt="image" src="https://github.com/user-attachments/assets/21ea46a4-d0b1-4717-ab03-78e11949c2ea" />


