### PR TITLE
Horror dice selection + Public API v1

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -243,6 +243,10 @@
       "SpendInsight":"Einsicht ausgeben",
       "RefreshInsight":"Einsicht erneuern",
       "ClearDicePool":"Zurücksetzen",
+      "DiscardDie": "Würfel verwerfen",
+      "DiscardAllDice": "Alle Würfel verwerfen",
+      "SpendRegularDie": "Normalen Würfel ausgeben",
+      "SpendHorrorDie": "Horrorwürfel ausgeben",
       "StrainOneself":"Sich belasten",
       "RefreshDicePool":"Erneuern",
       "Roll": "Würfeln",
@@ -335,7 +339,14 @@
       "RollReactionRequiresOneDie": "Reaktionswürfe erfordern 1 Würfel aus deinem Pool.",
       "RollAdvDisadvRequiresDie": "Vorteil/Nachteil erfordert mindestens 1 gewürfelten Würfel.",
       "RollMustRollAtLeastOneDie": "Du musst mindestens 1 Würfel würfeln.",
+      "RollSpendFailed": "Die Würfelkosten für diesen Wurf konnten nicht ausgegeben werden.",
       "RollPostProcessingFailed": "Nachbearbeitung nach dem Wurf ist fehlgeschlagen.",
+      "SimpleActionInsufficientHorror": "Du hast nicht genug Horrorwürfel zum Ausgeben.",
+      "SimpleActionInsufficientRegular": "Du hast nicht genug normale Würfel zum Ausgeben.",
+      "SimpleActionInsufficientDicepool": "Du hast nicht genug Würfel im Pool.",
+      "SimpleActionInvalidAmount": "Ungültiger Betrag für eine einfache Aktion.",
+      "SimpleActionInvalidHorrorSplit": "Die Anzahl der eingesetzten Horrorwürfel ist für diesen Wurf ungültig.",
+      "SimpleActionSpendFailed": "Ausgeben für einfache Aktion fehlgeschlagen.",
 
       "InjuryTraumaFallingModeInjuryOnly": "Der Fallmodus gilt nur für Verletzungswürfe.",
       "InjuryTraumaFallingHeightMin": "Die Fallhöhe muss mindestens {minFt} ft betragen.",
@@ -453,11 +464,21 @@
         "Changed": "Würfelpool von {actorName} änderte sich von {oldDicePoolValue} auf {newDicePoolValue}.",
         "HealedDamage": "{healedDamage} Schaden geheilt"
       },
+      "DicepoolDiscard": {
+        "Label": "Würfelpool verwerfen",
+        "Spent": "{actorName} hat {amount} Würfel verworfen (normal: {discardedRegular}, Horror: {discardedHorror}) ({oldDicePoolValue} → {newDicePoolValue})."
+      },
       "Insight": {
         "LabelSpent": "Einsicht ausgegeben",
         "LabelRefreshed": "Einsicht erneuert",
         "Spent": "{actorName} gab {spent} Einsicht aus ({oldRemaining} → {newRemaining}/{limit}).",
         "Refreshed": "{actorName}s Einsicht wurde von {oldRemaining} auf {newRemaining} erneuert."
+      },
+      "SimpleAction": {
+        "Label": "Einfache Aktion",
+        "Spent": "{actorName} hat {amount} {dieTypeLabel} ausgegeben ({oldDicePoolValue} → {newDicePoolValue} Würfelpool).",
+        "DieTypeHorror": "Horrorwürfel",
+        "DieTypeRegular": "Normaler Würfel"
       },
       "InjuryTrauma": {
         "FallingTooltip": "Fallen",
@@ -507,6 +528,8 @@
         "RefreshUses": "Verwendungen erneuern",
         "None": "Keine",
         "AdvPlusDisadv": "Vorteil + Nachteil",
+        "HorrorDiceToUse": "Horrorwürfel",
+        "HorrorDiceToUseHint": "Verfügbare Horrorwürfel: {available}. Maximum für diesen Wurf: {max}.",
         "InjuriesAffectingRoll": "Verletzungen, die diesen Wurf beeinflussen",
         "TotalPenalty": "Gesamtmalus",
         "InjuriesAutoAppliedHint": "Diese Mali werden automatisch von aktiven Verletzungen angewendet (Doppelte stapeln nicht).",

--- a/lang/de.json
+++ b/lang/de.json
@@ -657,7 +657,8 @@
       "reloadCost": "Nachladekosten",
       "weight": "Gewicht",
       "reloadAfterUsage": "Nach Gebrauch nachladen",
-      "isRelic": "Relikt"
+      "isRelic": "Relikt",
+      "decreaseAfterUsage": "Munition nach Gebrauch verringern"
     },
     "ProtectiveEquipment": {
       "defensiveBenefit": "Defensiver Vorteil",

--- a/lang/en.json
+++ b/lang/en.json
@@ -243,6 +243,10 @@
       "SpendInsight": "Spend Insight",
       "RefreshInsight": "Refresh Insight",
       "ClearDicePool": "Clear",
+      "DiscardDie": "Discard Die",
+      "DiscardAllDice": "Discard All Dice",
+      "SpendRegularDie": "Spend Regular Die",
+      "SpendHorrorDie": "Spend Horror Die",
       "StrainOneself": "Strain Oneself",
       "RefreshDicePool": "Refresh",
       "Roll": "Roll",
@@ -335,7 +339,14 @@
       "RollReactionRequiresOneDie": "Reaction rolls require 1 die from your pool.",
       "RollAdvDisadvRequiresDie": "Advantage/Disadvantage requires rolling at least 1 die.",
       "RollMustRollAtLeastOneDie": "You must roll at least 1 die.",
+      "RollSpendFailed": "Failed to spend dice for this roll.",
       "RollPostProcessingFailed": "Post-roll processing failed.",
+      "SimpleActionInsufficientHorror": "You do not have enough horror dice to spend.",
+      "SimpleActionInsufficientRegular": "You do not have enough regular dice to spend.",
+      "SimpleActionInsufficientDicepool": "You do not have enough dice in your pool.",
+      "SimpleActionInvalidAmount": "Simple Action spend amount is invalid.",
+      "SimpleActionInvalidHorrorSplit": "Horror dice to use is invalid for this roll.",
+      "SimpleActionSpendFailed": "Simple Action spend failed.",
 
       "InjuryTraumaFallingModeInjuryOnly": "Falling mode only applies to Injury rolls.",
       "InjuryTraumaFallingHeightMin": "Falling height must be at least {minFt} ft.",
@@ -453,11 +464,21 @@
         "Changed": "{actorName}'s dice pool changed from {oldDicePoolValue} to {newDicePoolValue}.",
         "HealedDamage": "Healed {healedDamage} damage"
       },
+      "DicepoolDiscard": {
+        "Label": "Dicepool Discard",
+        "Spent": "{actorName} discarded {amount} dice (regular: {discardedRegular}, horror: {discardedHorror}) ({oldDicePoolValue} → {newDicePoolValue})."
+      },
       "Insight": {
         "LabelSpent": "Insight Spent",
         "LabelRefreshed": "Insight Refreshed",
         "Spent": "{actorName} spent {spent} Insight ({oldRemaining} → {newRemaining}/{limit}).",
         "Refreshed": "{actorName}'s Insight has been refreshed from {oldRemaining} to {newRemaining}."
+      },
+      "SimpleAction": {
+        "Label": "Simple Action",
+        "Spent": "{actorName} spent {amount} {dieTypeLabel} ({oldDicePoolValue} → {newDicePoolValue} dice pool).",
+        "DieTypeHorror": "Horror Die",
+        "DieTypeRegular": "Regular Die"
       },
       "InjuryTrauma": {
         "FallingTooltip": "Falling",
@@ -507,6 +528,8 @@
         "RefreshUses": "Refresh uses",
         "None": "None",
         "AdvPlusDisadv": "Adv + Disadvantage",
+        "HorrorDiceToUse": "Horror Dice",
+        "HorrorDiceToUseHint": "Available horror dice: {available}. Max for this roll: {max}.",
         "InjuriesAffectingRoll": "Injuries affecting this roll",
         "TotalPenalty": "Total penalty",
         "InjuriesAutoAppliedHint": "These penalties are applied automatically from active injuries (duplicates do not stack).",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -667,7 +667,8 @@
       "reloadCost": "Coût de rechargement",
       "weight": "Poids",
       "reloadAfterUsage": "Recharger après utilisation",
-      "isRelic": "Relique"
+      "isRelic": "Relique",
+      "decreaseAfterUsage": "Diminuer les munitions après utilisation"
     },
     "ProtectiveEquipment": {
       "defensiveBenefit": "Bénéfice défensif",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -247,6 +247,10 @@
       "SpendInsight": "Dépenser de la lucidité",
       "RefreshInsight": "Récupérer de la lucidité",
       "ClearDicePool": "Vider",
+      "DiscardDie": "Défausser un dé",
+      "DiscardAllDice": "Défausser tous les dés",
+      "SpendRegularDie": "Dépenser un dé normal",
+      "SpendHorrorDie": "Dépenser un dé d’horreur",
       "StrainOneself": "Se dépasser",
       "RefreshDicePool": "Rafraîchir",
       "Roll": "Lancer",
@@ -340,7 +344,14 @@
       "RollReactionRequiresOneDie": "Les jets de réaction nécessitent 1 dé de votre réserve.",
       "RollAdvDisadvRequiresDie": "L’avantage ou le désavantage nécessite de lancer au moins 1 dé.",
       "RollMustRollAtLeastOneDie": "Vous devez lancer au moins 1 dé.",
+      "RollSpendFailed": "Impossible de dépenser les dés pour ce jet.",
       "RollPostProcessingFailed": "Le traitement après le jet a échoué.",
+      "SimpleActionInsufficientHorror": "Vous n’avez pas assez de dés d’horreur à dépenser.",
+      "SimpleActionInsufficientRegular": "Vous n’avez pas assez de dés normaux à dépenser.",
+      "SimpleActionInsufficientDicepool": "Votre réserve de dés est insuffisante.",
+      "SimpleActionInvalidAmount": "Montant invalide pour une action simple.",
+      "SimpleActionInvalidHorrorSplit": "Le nombre de dés d’horreur utilisés est invalide pour ce jet.",
+      "SimpleActionSpendFailed": "Échec de la dépense pour l’action simple.",
 
       "InjuryTraumaFallingModeInjuryOnly": "Le mode chute s’applique uniquement aux jets de blessure.",
       "InjuryTraumaFallingHeightMin": "La hauteur de chute doit être d’au moins {minFt} m.",
@@ -460,11 +471,21 @@
         "Changed": "La réserve de dés de {actorName} est passée de {oldDicePoolValue} à {newDicePoolValue}.",
         "HealedDamage": "{healedDamage} dégât(s) soigné(s)"
       },
+      "DicepoolDiscard": {
+        "Label": "Défausse de réserve de dés",
+        "Spent": "{actorName} a défaussé {amount} dés (normaux : {discardedRegular}, horreur : {discardedHorror}) ({oldDicePoolValue} → {newDicePoolValue})."
+      },
       "Insight": {
         "LabelSpent": "Lucidité dépensée",
         "LabelRefreshed": "Lucidité récupérée",
         "Spent": "{actorName} a dépensé {spent} lucidité ({oldRemaining} → {newRemaining}/{limit}).",
         "Refreshed": "La lucidité de {actorName} a été récupérée ({oldRemaining} → {newRemaining})."
+      },
+      "SimpleAction": {
+        "Label": "Action simple",
+        "Spent": "{actorName} a dépensé {amount} {dieTypeLabel} ({oldDicePoolValue} → {newDicePoolValue} réserve de dés).",
+        "DieTypeHorror": "dé d’horreur",
+        "DieTypeRegular": "dé normal"
       },
       "InjuryTrauma": {
         "FallingTooltip": "Chute",
@@ -515,6 +536,8 @@
         "RefreshUses": "Récupérer les utilisations",
         "None": "Aucun",
         "AdvPlusDisadv": "Avantage + Désavantage",
+        "HorrorDiceToUse": "Dés d’horreur",
+        "HorrorDiceToUseHint": "Dés d’horreur disponibles : {available}. Maximum pour ce jet : {max}.",
         "InjuriesAffectingRoll": "Blessures affectant ce jet",
         "TotalPenalty": "Pénalité totale",
         "InjuriesAutoAppliedHint": "Ces pénalités sont appliquées automatiquement par les blessures actives (les doublons ne se cumulent pas).",

--- a/module/api/dicepool/index.mjs
+++ b/module/api/dicepool/index.mjs
@@ -1,0 +1,197 @@
+import { refreshDicepoolAndPost } from "../../helpers/dicepool.mjs";
+import { openInjuryTraumaDialog } from "../rolls/index.mjs";
+
+function toNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function snapshot(actor) {
+  const value = Math.max(0, toNumber(actor?.system?.dicepool?.value, 0));
+  const max = Math.max(0, toNumber(actor?.system?.dicepool?.max, 0));
+  const damage = Math.max(0, toNumber(actor?.system?.damage, 0));
+  const horror = Math.max(0, toNumber(actor?.system?.horror, 0));
+  const rawHorrorInPool = actor?.system?.dicepool?.horrorInPool;
+  const storedHorrorInPool = (rawHorrorInPool === null || rawHorrorInPool === undefined)
+    ? Number.NaN
+    : toNumber(rawHorrorInPool, Number.NaN);
+  const fallbackHorrorInPool = Math.min(horror, value);
+  const horrorInPool = Number.isFinite(storedHorrorInPool)
+    ? Math.max(0, Math.min(storedHorrorInPool, value, horror))
+    : fallbackHorrorInPool;
+  return { value, max, damage, horror, horrorInPool };
+}
+
+function resolveHorrorInPoolAfterValueChange(state, nextValue) {
+  const next = Math.max(0, toNumber(nextValue, 0));
+  const prevValue = Math.max(0, toNumber(state?.value, 0));
+  const prevHorrorInPool = Math.max(0, toNumber(state?.horrorInPool, 0));
+  const horrorLimit = Math.max(0, toNumber(state?.horror, 0));
+  const maxHorrorAtNext = Math.min(horrorLimit, next);
+
+  // On decreases, preserve composition as much as possible and clamp.
+  if (next <= prevValue) {
+    return Math.max(0, Math.min(prevHorrorInPool, maxHorrorAtNext));
+  }
+
+  // On increases, refill horror first before regular dice.
+  const addedDice = next - prevValue;
+  const missingHorror = Math.max(0, maxHorrorAtNext - prevHorrorInPool);
+  const horrorGained = Math.min(addedDice, missingHorror);
+  return Math.max(0, Math.min(prevHorrorInPool + horrorGained, maxHorrorAtNext));
+}
+
+export async function adjustDamage(actor, {
+  delta,
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const state = snapshot(actor);
+  const step = Number.parseInt(delta) || 0;
+  const next = Math.min(state.max, Math.max(0, state.damage + step));
+
+  await actor.update({ "system.damage": next });
+  return { ok: true, reason: null, oldDamage: state.damage, newDamage: next };
+}
+
+export async function adjustHorror(actor, {
+  delta,
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const state = snapshot(actor);
+  const step = Number.parseInt(delta) || 0;
+  const next = Math.min(state.max, Math.max(0, state.horror + step));
+  const nextHorrorInPool = Math.max(0, Math.min(state.horrorInPool, next, state.value));
+
+  await actor.update({
+    "system.horror": next,
+    "system.dicepool.horrorInPool": nextHorrorInPool,
+  });
+
+  return {
+    ok: true,
+    reason: null,
+    oldHorror: state.horror,
+    newHorror: next,
+    oldHorrorInPool: state.horrorInPool,
+    newHorrorInPool: nextHorrorInPool,
+  };
+}
+
+export async function adjustValue(actor, {
+  delta,
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const state = snapshot(actor);
+  const step = Number.parseInt(delta) || 0;
+  const effectiveMax = Math.max(0, state.max - state.damage);
+  const next = Math.min(effectiveMax, Math.max(0, state.value + step));
+  const nextHorrorInPool = resolveHorrorInPoolAfterValueChange(state, next);
+
+  await actor.update({
+    "system.dicepool.value": next,
+    "system.dicepool.horrorInPool": nextHorrorInPool,
+  });
+
+  return {
+    ok: true,
+    reason: null,
+    oldValue: state.value,
+    newValue: next,
+    oldHorrorInPool: state.horrorInPool,
+    newHorrorInPool: nextHorrorInPool,
+  };
+}
+
+export async function setValue(actor, {
+  value,
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const state = snapshot(actor);
+  const requested = Math.max(0, Number.parseInt(value) || 0);
+  const effectiveMax = Math.max(0, state.max - state.damage);
+  const next = Math.min(effectiveMax, requested);
+  const nextHorrorInPool = resolveHorrorInPoolAfterValueChange(state, next);
+
+  await actor.update({
+    "system.dicepool.value": next,
+    "system.dicepool.horrorInPool": nextHorrorInPool,
+  });
+
+  return {
+    ok: true,
+    reason: null,
+    oldValue: state.value,
+    newValue: next,
+    oldHorrorInPool: state.horrorInPool,
+    newHorrorInPool: nextHorrorInPool,
+  };
+}
+
+export async function refresh(actor, {
+  label = game.i18n.localize("ARKHAM_HORROR.DICEPOOL.Chat.Refresh"),
+  healDamage = false,
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const result = await refreshDicepoolAndPost({
+    actor,
+    label,
+    healDamage,
+  });
+
+  return {
+    ok: true,
+    reason: null,
+    ...result,
+  };
+}
+
+export async function strain(actor, {
+  source = "api",
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  if (!actor?.isOwner) {
+    ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.Warnings.PermissionStrainActor"));
+    return { ok: false, reason: "PERMISSION_DENIED" };
+  }
+
+  const currentDamage = Number(actor.system?.damage ?? 0) || 0;
+  if (currentDamage <= 0) {
+    ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.Warnings.StrainRequiresDamage"));
+    return { ok: false, reason: "NO_DAMAGE_TO_STRAIN" };
+  }
+
+  const refreshResult = await refreshDicepoolAndPost({
+    actor,
+    label: game.i18n.localize("ARKHAM_HORROR.ACTIONS.StrainOneself"),
+    healDamage: true,
+  });
+
+  const injuryResult = await openInjuryTraumaDialog(actor, {
+    rollKind: "injury",
+    rollSource: "strain",
+  });
+
+  return {
+    ok: true,
+    reason: null,
+    source,
+    refresh: refreshResult,
+    injury: injuryResult,
+  };
+}
+
+export const dicepoolApi = {
+  version: "v1",
+  adjustDamage,
+  adjustHorror,
+  adjustValue,
+  setValue,
+  refresh,
+  strain,
+};

--- a/module/api/insight/index.mjs
+++ b/module/api/insight/index.mjs
@@ -1,0 +1,51 @@
+import { SpendInsightApp } from "../../apps/spend-insight-app.mjs";
+import { refreshInsightAndPost, spendInsightAndPost } from "../../helpers/insight.mjs";
+
+function hasInsightPermission(actor) {
+  return !!(actor?.isOwner || game.user?.isGM);
+}
+
+export async function openSpendDialog(actor) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+  if (actor?.type === "vehicle") return { ok: false, reason: "ACTOR_TYPE_UNSUPPORTED" };
+
+  if (!hasInsightPermission(actor)) {
+    ui.notifications.warn(game.i18n.localize("ARKHAM_HORROR.INSIGHT.Errors.PermissionSpend"));
+    return { ok: false, reason: "PERMISSION_DENIED" };
+  }
+
+  if (actor?.type !== "character") return { ok: false, reason: "ACTOR_TYPE_UNSUPPORTED" };
+
+  const remaining = Number(actor.system?.insight?.remaining ?? 0) || 0;
+  if (remaining <= 0) {
+    ui.notifications.warn(game.i18n.format("ARKHAM_HORROR.INSIGHT.Errors.NoneRemaining", { actorName: actor.name }));
+    return { ok: false, reason: "INSIGHT_NONE_REMAINING" };
+  }
+
+  SpendInsightApp.getInstance({ actor }).render(true);
+  return { ok: true, reason: null };
+}
+
+export async function spendAndPost(actor, {
+  amount = 1,
+  source = "api",
+  rollMode = "roll",
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+  return spendInsightAndPost({ actor, amount, source, rollMode });
+}
+
+export async function refreshAndPost(actor, {
+  source = "api",
+  rollMode = "roll",
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+  return refreshInsightAndPost({ actor, source, rollMode });
+}
+
+export const insightApi = {
+  version: "v1",
+  openSpendDialog,
+  spendAndPost,
+  refreshAndPost,
+};

--- a/module/api/resources/index.mjs
+++ b/module/api/resources/index.mjs
@@ -1,0 +1,182 @@
+import {
+  canSpendDice,
+  previewDiceSpend,
+  spendSimpleActionDie as spendSimpleActionDieHelper,
+  spendRollCost as spendRollCostHelper,
+  discardDice as discardDiceHelper,
+  discardAllDice as discardAllDiceHelper,
+} from "../../helpers/resources.mjs";
+
+export function canSpend(actor, {
+  resourceType = "dicepool",
+  amount,
+  breakdown,
+  context,
+} = {}) {
+  if (resourceType !== "dicepool") {
+    return {
+      ok: false,
+      reason: "UNSUPPORTED_RESOURCE",
+      maxSpendable: 0,
+      failures: ["UNSUPPORTED_RESOURCE"],
+      context: { type: String(context ?? "simple") || "simple" },
+    };
+  }
+
+  return canSpendDice(actor, {
+    totalDiceCost: amount,
+    horrorDiceCost: breakdown?.horror,
+    context,
+  });
+}
+
+export function previewSpend(actor, {
+  resourceType = "dicepool",
+  amount,
+  breakdown,
+  context,
+} = {}) {
+  if (resourceType !== "dicepool") {
+    return {
+      ok: false,
+      reason: "UNSUPPORTED_RESOURCE",
+      warnings: [],
+      context: { type: String(context ?? "simple") || "simple" },
+      resource: {
+        type: String(resourceType),
+        amountRequested: Number(amount ?? 0) || 0,
+        breakdownRequested: breakdown ?? {},
+      },
+      applied: { total: 0, breakdown: {} },
+      before: {},
+      after: {},
+      chat: { posted: false },
+      meta: { actorId: String(actor?.id ?? ""), timestamp: new Date().toISOString(), version: "v1" },
+    };
+  }
+
+  return previewDiceSpend(actor, {
+    totalDiceCost: amount,
+    horrorDiceCost: breakdown?.horror,
+    context,
+  });
+}
+
+export async function spendResource(actor, {
+  resourceType = "dicepool",
+  amount,
+  breakdown,
+  context,
+  postChat = true,
+  chatVisibility = "public",
+  source,
+} = {}) {
+  if (resourceType !== "dicepool") {
+    return {
+      ok: false,
+      reason: "UNSUPPORTED_RESOURCE",
+      warnings: [],
+      context: { type: String(context ?? "simple") || "simple", source },
+      resource: {
+        type: String(resourceType),
+        amountRequested: Number(amount ?? 0) || 0,
+        breakdownRequested: breakdown ?? {},
+      },
+      applied: { total: 0, breakdown: {} },
+      before: {},
+      after: {},
+      chat: { posted: false },
+      meta: { actorId: String(actor?.id ?? ""), timestamp: new Date().toISOString(), version: "v1" },
+    };
+  }
+
+  const contextType = String(context ?? "simple") || "simple";
+  if (contextType === "simple" && Number(amount ?? 0) === 1 && (breakdown?.horror === 1 || breakdown?.regular === 1)) {
+    const dieType = breakdown?.horror === 1 ? "horror" : "regular";
+    return spendSimpleActionDie(actor, {
+      dieType,
+      context: contextType,
+      postChat,
+      chatVisibility,
+      source,
+    });
+  }
+
+  return spendRollCost(actor, {
+    totalDiceCost: amount,
+    horrorDiceCost: breakdown?.horror,
+    context: contextType,
+    source,
+  });
+}
+
+export async function spendSimpleActionDie(actor, {
+  dieType = "regular",
+  context = "simple",
+  postChat = true,
+  chatVisibility = "public",
+  source = "sheet",
+} = {}) {
+  return spendSimpleActionDieHelper(actor, {
+    dieType,
+    context,
+    postChat,
+    chatVisibility,
+    source,
+  });
+}
+
+export async function spendRollCost(actor, {
+  totalDiceCost,
+  horrorDiceCost,
+  context = "complex",
+  source = "workflow",
+} = {}) {
+  return spendRollCostHelper(actor, {
+    totalDiceCost,
+    horrorDiceCost,
+    context,
+    source,
+  });
+}
+
+export async function discardDice(actor, {
+  amount = 1,
+  context = "discard",
+  postChat = true,
+  chatVisibility = "public",
+  source = "sheet",
+} = {}) {
+  return discardDiceHelper(actor, {
+    amount,
+    context,
+    postChat,
+    chatVisibility,
+    source,
+  });
+}
+
+export async function discardAllDice(actor, {
+  context = "discard",
+  postChat = true,
+  chatVisibility = "public",
+  source = "sheet",
+} = {}) {
+  return discardAllDiceHelper(actor, {
+    context,
+    postChat,
+    chatVisibility,
+    source,
+  });
+}
+
+export const resourcesApi = {
+  version: "v1",
+  canSpend,
+  previewSpend,
+  spendResource,
+  spendSimpleActionDie,
+  spendRollCost,
+  discardDice,
+  discardAllDice,
+};

--- a/module/api/rolls/index.mjs
+++ b/module/api/rolls/index.mjs
@@ -1,0 +1,168 @@
+import { DiceRollApp } from "../../apps/dice-roll-app.mjs";
+import { InjuryTraumaRollApp } from "../../apps/injury-trauma-roll-app.mjs";
+
+function getSkillSnapshot(actor, skillKey) {
+  const key = String(skillKey ?? "").trim();
+  const skillData = actor?.system?.skills?.[key];
+  if (!key || !skillData) return null;
+
+  return {
+    skillKey: key,
+    skillCurrent: Number(skillData.current ?? skillData.value ?? 0) || 0,
+    skillMax: Number(skillData.max ?? 0) || 0,
+    currentDicePool: Number(actor?.system?.dicepool?.value ?? actor?.system?.dicePool?.value ?? 0) || 0,
+  };
+}
+
+export async function openSkillDialog(actor, {
+  skillKey,
+  rollKind = "complex",
+  weaponToUse = null,
+  spellToUse = null,
+  successesNeeded,
+  afterRoll,
+  skillChoices,
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const snapshot = getSkillSnapshot(actor, skillKey);
+  if (!snapshot) {
+    return {
+      ok: false,
+      reason: "SKILL_NOT_FOUND",
+      skillKey: String(skillKey ?? ""),
+    };
+  }
+
+  DiceRollApp.getInstance({
+    actor,
+    rollKind,
+    skillKey: snapshot.skillKey,
+    skillCurrent: snapshot.skillCurrent,
+    skillMax: snapshot.skillMax,
+    currentDicePool: snapshot.currentDicePool,
+    weaponToUse,
+    spellToUse,
+    successesNeeded,
+    afterRoll,
+    skillChoices,
+  }).render(true);
+
+  return {
+    ok: true,
+    reason: null,
+    rollKind: String(rollKind ?? "complex"),
+    skillKey: snapshot.skillKey,
+  };
+}
+
+export async function openReactionDialog(actor, {
+  skillKey,
+  rollKind = "reaction",
+} = {}) {
+  return openSkillDialog(actor, {
+    skillKey,
+    rollKind,
+    weaponToUse: null,
+    spellToUse: null,
+  });
+}
+
+export async function openWeaponDialog(actor, {
+  itemId,
+  rollKind = "complex",
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const item = actor.items?.get?.(itemId);
+  if (!item) return { ok: false, reason: "ITEM_NOT_FOUND", itemId: String(itemId ?? "") };
+
+  const ammoMax = Number(item.system?.ammunition?.max ?? 0) || 0;
+  const ammoCurrent = Number(item.system?.ammunition?.current ?? 0) || 0;
+  if (ammoMax > 0 && ammoCurrent <= 0) {
+    ui.notifications.warn(game.i18n.format("ARKHAM_HORROR.Warnings.WeaponOutOfAmmo", { itemName: item.name }));
+    return { ok: false, reason: "WEAPON_OUT_OF_AMMO", itemId: String(item.id ?? itemId ?? "") };
+  }
+
+  const skillKey = String(item.system?.skill ?? "");
+  const snapshot = getSkillSnapshot(actor, skillKey);
+  if (!snapshot) {
+    return {
+      ok: false,
+      reason: "SKILL_NOT_FOUND",
+      itemId: String(item.id ?? itemId ?? ""),
+      skillKey,
+    };
+  }
+
+  return openSkillDialog(actor, {
+    skillKey,
+    rollKind,
+    weaponToUse: item,
+    spellToUse: null,
+  });
+}
+
+export async function openSpellDialog(actor, {
+  itemId,
+  rollKind = "complex",
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  const item = actor.items?.get?.(itemId);
+  if (!item) return { ok: false, reason: "ITEM_NOT_FOUND", itemId: String(itemId ?? "") };
+
+  const skillKey = String(item.system?.skill ?? "");
+  const snapshot = getSkillSnapshot(actor, skillKey);
+  if (!snapshot) {
+    return {
+      ok: false,
+      reason: "SKILL_NOT_FOUND",
+      itemId: String(item.id ?? itemId ?? ""),
+      skillKey,
+    };
+  }
+
+  return openSkillDialog(actor, {
+    skillKey,
+    rollKind,
+    spellToUse: item,
+    weaponToUse: null,
+  });
+}
+
+export async function openInjuryTraumaDialog(actor, {
+  rollKind = "injury",
+  rollSource = "",
+  modifier,
+  dieFaces,
+  rollMode,
+  fallingHeightFt,
+} = {}) {
+  if (!actor) return { ok: false, reason: "ACTOR_REQUIRED" };
+
+  InjuryTraumaRollApp.getInstance({
+    actor,
+    rollKind,
+    rollSource,
+    modifier,
+    dieFaces,
+    rollMode,
+    fallingHeightFt,
+  }).render(true);
+
+  return {
+    ok: true,
+    reason: null,
+    rollKind: String(rollKind ?? "injury"),
+  };
+}
+
+export const rollsApi = {
+  version: "v1",
+  openSkillDialog,
+  openReactionDialog,
+  openWeaponDialog,
+  openSpellDialog,
+  openInjuryTraumaDialog,
+};

--- a/module/arkham-horror-rpg-fvtt.mjs
+++ b/module/arkham-horror-rpg-fvtt.mjs
@@ -28,6 +28,10 @@ import { applyKnackGrantsOnAcquire, removeKnackGrantedSpellsOnDelete } from './h
 
 import { refreshDicepoolAndPost } from './helpers/dicepool.mjs';
 import * as money from './helpers/money.mjs';
+import { resourcesApi } from './api/resources/index.mjs';
+import { rollsApi } from './api/rolls/index.mjs';
+import { insightApi } from './api/insight/index.mjs';
+import { dicepoolApi } from './api/dicepool/index.mjs';
 
 
 /* -------------------------------------------- */
@@ -46,6 +50,19 @@ Hooks.once('init', function () {
     spendInsightAndPost,
     refreshInsightAndPost,
     money,
+    api: {
+      version: "v1",
+      capabilities: {
+        resources: resourcesApi.version,
+        rolls: rollsApi.version,
+        insight: insightApi.version,
+        dicepool: dicepoolApi.version,
+      },
+      resources: resourcesApi,
+      rolls: rollsApi,
+      insight: insightApi,
+      dicepool: dicepoolApi,
+    },
   };
 
   // Add custom constants for configuration.

--- a/module/helpers/dicepool-state.mjs
+++ b/module/helpers/dicepool-state.mjs
@@ -1,0 +1,51 @@
+function asInt(value, fallback = 0) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function getDicepoolResourceBounds(actor, { currentDicePool } = {}) {
+  const poolValue = Math.max(
+    0,
+    currentDicePool === undefined
+      ? asInt(actor?.system?.dicepool?.value, 0)
+      : asInt(currentDicePool, 0),
+  );
+
+  const horrorLimit = Math.max(0, asInt(actor?.system?.horror, 0));
+  const storedHorrorInPool = asInt(actor?.system?.dicepool?.horrorInPool, Number.NaN);
+  const availableHorror = Number.isFinite(storedHorrorInPool)
+    ? Math.max(0, Math.min(storedHorrorInPool, poolValue, horrorLimit))
+    : Math.min(horrorLimit, poolValue);
+  const availableRegular = Math.max(0, poolValue - availableHorror);
+
+  return {
+    currentDicePool: poolValue,
+    horrorLimit,
+    availableHorror,
+    availableRegular,
+  };
+}
+
+export function getHorrorSpendBounds(actor, {
+  currentDicePool,
+  diceToUse,
+  horrorDiceToUse,
+} = {}) {
+  const resourceBounds = getDicepoolResourceBounds(actor, { currentDicePool });
+  const selectedDiceToUse = Math.max(0, asInt(diceToUse, 0));
+  const minHorrorDiceToUse = Math.max(0, selectedDiceToUse - resourceBounds.availableRegular);
+  const maxHorrorDiceToUse = Math.min(resourceBounds.availableHorror, selectedDiceToUse);
+  const clampedHorrorMin = Math.min(minHorrorDiceToUse, maxHorrorDiceToUse);
+  const clampedHorrorDiceToUse = Math.max(
+    clampedHorrorMin,
+    Math.min(maxHorrorDiceToUse, asInt(horrorDiceToUse, 0)),
+  );
+
+  return {
+    ...resourceBounds,
+    selectedDiceToUse,
+    minHorrorDiceToUse,
+    maxHorrorDiceToUse,
+    clampedHorrorDiceToUse,
+  };
+}

--- a/module/helpers/dicepool.mjs
+++ b/module/helpers/dicepool.mjs
@@ -14,13 +14,17 @@ export async function refreshDicepoolAndPost({
 
   const oldDamage = Number(actor.system?.damage ?? 0);
   const oldDicePoolValue = Number(actor.system?.dicepool?.value ?? 0);
+  const oldHorrorInPool = Number(actor.system?.dicepool?.horrorInPool ?? 0);
   const dicePoolMax = Number(actor.system?.dicepool?.max ?? 0);
+  const horrorLimit = Number(actor.system?.horror ?? 0);
 
   const newDamage = healDamage ? 0 : oldDamage;
   const newDicePoolValue = Math.max(0, dicePoolMax - newDamage);
+  const newHorrorInPool = Math.max(0, Math.min(horrorLimit, newDicePoolValue));
 
   const updateData = {
     "system.dicepool.value": newDicePoolValue,
+    "system.dicepool.horrorInPool": newHorrorInPool,
   };
   if (healDamage && oldDamage !== 0) updateData["system.damage"] = 0;
 
@@ -33,6 +37,8 @@ export async function refreshDicepoolAndPost({
     actorName: actor.name,
     oldDicePoolValue,
     newDicePoolValue,
+    oldHorrorInPool,
+    newHorrorInPool,
     healedDamage,
   };
 
@@ -51,5 +57,7 @@ export async function refreshDicepoolAndPost({
     healedDamage,
     oldDicePoolValue,
     newDicePoolValue,
+    oldHorrorInPool,
+    newHorrorInPool,
   };
 }

--- a/module/helpers/resources.mjs
+++ b/module/helpers/resources.mjs
@@ -1,0 +1,451 @@
+import { createArkhamHorrorChatCard } from "../util/chat-utils.mjs";
+
+const SYSTEM_ID = "arkham-horror-rpg-fvtt";
+const SIMPLE_ACTION_TEMPLATE = `systems/${SYSTEM_ID}/templates/chat/simple-action-spend.hbs`;
+const DICEPOOL_DISCARD_TEMPLATE = `systems/${SYSTEM_ID}/templates/chat/dicepool-discard.hbs`;
+
+function toNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function toContextType(value) {
+  const raw = String(value ?? "simple").trim();
+  return raw || "simple";
+}
+
+function toRollMode(visibility) {
+  const map = {
+    public: "roll",
+    owner: "selfroll",
+    gm: "gmroll",
+  };
+  const key = String(visibility ?? "public").toLowerCase();
+  return map[key] ?? "roll";
+}
+
+function buildEnvelope({
+  ok,
+  reason = null,
+  warnings = [],
+  context,
+  amountRequested,
+  breakdownRequested,
+  appliedTotal,
+  appliedBreakdown,
+  before,
+  after,
+  chat,
+  actor,
+}) {
+  return {
+    ok: !!ok,
+    reason,
+    warnings: Array.isArray(warnings) ? warnings : [],
+    context,
+    resource: {
+      type: "dicepool",
+      amountRequested: toNumber(amountRequested, 0),
+      breakdownRequested: breakdownRequested ?? {},
+    },
+    applied: {
+      total: toNumber(appliedTotal, 0),
+      breakdown: appliedBreakdown ?? {},
+    },
+    before,
+    after,
+    chat,
+    meta: {
+      actorId: String(actor?.id ?? ""),
+      timestamp: new Date().toISOString(),
+      version: "v1",
+    },
+  };
+}
+
+function getDiceSnapshot(actor) {
+  const dicepool = Math.max(0, toNumber(actor?.system?.dicepool?.value, 0));
+  const horrorLimit = Math.max(0, toNumber(actor?.system?.horror, 0));
+  const rawHorrorInPool = actor?.system?.dicepool?.horrorInPool;
+  const storedHorrorInPool = (rawHorrorInPool === null || rawHorrorInPool === undefined)
+    ? Number.NaN
+    : toNumber(rawHorrorInPool, Number.NaN);
+  const fallbackHorrorInPool = Math.min(horrorLimit, dicepool);
+  const horrorInPool = Number.isFinite(storedHorrorInPool)
+    ? Math.max(0, Math.min(storedHorrorInPool, dicepool, horrorLimit))
+    : fallbackHorrorInPool;
+  const regular = Math.max(0, dicepool - horrorInPool);
+  return { dicepool, horror: horrorInPool, horrorInPool, horrorLimit, regular };
+}
+
+function hasSpendPermission(actor) {
+  return !!(actor?.isOwner || game.user?.isGM);
+}
+
+function resolveAutoHorrorSpend({ totalDiceCost, snapshot }) {
+  const total = Math.max(0, toNumber(totalDiceCost, 0));
+  if (total <= 0) return 0;
+
+  const normalDice = Math.max(0, snapshot.dicepool - snapshot.horror);
+  if (normalDice >= total) return 0;
+  return Math.min(snapshot.horror, total - normalDice);
+}
+
+function validateDiceSpend({ snapshot, totalDiceCost, horrorDiceCost }) {
+  const total = Math.max(0, toNumber(totalDiceCost, 0));
+  const horror = Math.max(0, toNumber(horrorDiceCost, 0));
+  const regular = Math.max(0, total - horror);
+
+  if (total <= 0) return { ok: false, reason: "AMOUNT_INVALID" };
+  if (horror > total) return { ok: false, reason: "HORROR_EXCEEDS_TOTAL" };
+  if (snapshot.dicepool < total) return { ok: false, reason: "INSUFFICIENT_DICEPOOL" };
+  if (snapshot.horror < horror) return { ok: false, reason: "INSUFFICIENT_HORROR" };
+  if (snapshot.regular < regular) return { ok: false, reason: "INSUFFICIENT_REGULAR" };
+
+  return { ok: true, regular, horror, total };
+}
+
+async function postSimpleActionChat({ actor, dieType, amount, before, after, chatVisibility = "public", source }) {
+  const dieTypeKey = dieType === "horror"
+    ? "ARKHAM_HORROR.Chat.SimpleAction.DieTypeHorror"
+    : "ARKHAM_HORROR.Chat.SimpleAction.DieTypeRegular";
+
+  const chatVars = {
+    actorName: actor.name,
+    amount,
+    dieType,
+    dieTypeLabel: game.i18n.localize(dieTypeKey),
+    oldDicePoolValue: before.dicepool,
+    newDicePoolValue: after.dicepool,
+  };
+
+  const flags = {
+    [SYSTEM_ID]: {
+      ...chatVars,
+      source: String(source ?? "sheet"),
+      rollCategory: "simple-action",
+      actionContext: "simple",
+    },
+  };
+
+  const message = await createArkhamHorrorChatCard(
+    { actor, template: SIMPLE_ACTION_TEMPLATE, chatVars, flags },
+    { rollMode: toRollMode(chatVisibility) },
+  );
+
+  return String(message?.id ?? "");
+}
+
+async function postDiscardChat({ actor, amount, discardedRegular, discardedHorror, before, after, chatVisibility = "public", source }) {
+  const chatVars = {
+    actorName: actor.name,
+    amount,
+    discardedRegular,
+    discardedHorror,
+    oldDicePoolValue: before.dicepool,
+    newDicePoolValue: after.dicepool,
+  };
+
+  const flags = {
+    [SYSTEM_ID]: {
+      ...chatVars,
+      source: String(source ?? "sheet"),
+      rollCategory: "dicepool-discard",
+      actionContext: "discard",
+    },
+  };
+
+  const message = await createArkhamHorrorChatCard(
+    { actor, template: DICEPOOL_DISCARD_TEMPLATE, chatVars, flags },
+    { rollMode: toRollMode(chatVisibility) },
+  );
+
+  return String(message?.id ?? "");
+}
+
+function resolveDiscardBreakdown({ snapshot, amount }) {
+  const requested = Math.max(0, toNumber(amount, 0));
+  const regular = Math.min(snapshot.regular, requested);
+  const horror = Math.max(0, requested - regular);
+  return { requested, regular, horror };
+}
+
+async function spendDiceCore({
+  actor,
+  totalDiceCost,
+  horrorDiceCost,
+  context = "simple",
+  postChat = false,
+  chatVisibility = "public",
+  source,
+}) {
+  const contextType = toContextType(context);
+
+  if (!actor) {
+    return buildEnvelope({
+      ok: false,
+      reason: "ACTOR_REQUIRED",
+      context: { type: contextType, source },
+      amountRequested: toNumber(totalDiceCost, 0),
+      breakdownRequested: { horror: toNumber(horrorDiceCost, 0), regular: Math.max(0, toNumber(totalDiceCost, 0) - toNumber(horrorDiceCost, 0)) },
+      appliedTotal: 0,
+      appliedBreakdown: { regular: 0, horror: 0 },
+      before: { dicepool: 0, horror: 0 },
+      after: { dicepool: 0, horror: 0 },
+      chat: { posted: false },
+      actor,
+    });
+  }
+
+  if (!hasSpendPermission(actor)) {
+    const snapshot = getDiceSnapshot(actor);
+    return buildEnvelope({
+      ok: false,
+      reason: "PERMISSION_DENIED",
+      context: { type: contextType, source },
+      amountRequested: toNumber(totalDiceCost, 0),
+      breakdownRequested: { horror: toNumber(horrorDiceCost, 0), regular: Math.max(0, toNumber(totalDiceCost, 0) - toNumber(horrorDiceCost, 0)) },
+      appliedTotal: 0,
+      appliedBreakdown: { regular: 0, horror: 0 },
+      before: { dicepool: snapshot.dicepool, horror: snapshot.horror },
+      after: { dicepool: snapshot.dicepool, horror: snapshot.horror },
+      chat: { posted: false },
+      actor,
+    });
+  }
+
+  const requestedTotal = Math.max(0, toNumber(totalDiceCost, 0));
+  const before = getDiceSnapshot(actor);
+
+  const requestedHorror = horrorDiceCost === undefined || horrorDiceCost === null
+    ? resolveAutoHorrorSpend({ totalDiceCost: requestedTotal, snapshot: before })
+    : Math.max(0, toNumber(horrorDiceCost, 0));
+
+  const validation = validateDiceSpend({ snapshot: before, totalDiceCost: requestedTotal, horrorDiceCost: requestedHorror });
+  if (!validation.ok) {
+    return buildEnvelope({
+      ok: false,
+      reason: validation.reason,
+      context: { type: contextType, source },
+      amountRequested: requestedTotal,
+      breakdownRequested: { horror: requestedHorror, regular: Math.max(0, requestedTotal - requestedHorror) },
+      appliedTotal: 0,
+      appliedBreakdown: { regular: 0, horror: 0 },
+      before: { dicepool: before.dicepool, horror: before.horror },
+      after: { dicepool: before.dicepool, horror: before.horror },
+      chat: { posted: false },
+      actor,
+    });
+  }
+
+  const updateData = {
+    "system.dicepool.value": Math.max(0, before.dicepool - validation.total),
+    "system.dicepool.horrorInPool": Math.max(0, before.horrorInPool - validation.horror),
+  };
+
+  await actor.update(updateData);
+
+  const after = getDiceSnapshot(actor);
+  const applied = {
+    total: validation.total,
+    regular: validation.regular,
+    horror: validation.horror,
+  };
+
+  let chatMessageId = undefined;
+  if (postChat && contextType === "simple") {
+    const dieType = validation.horror > 0 ? "horror" : "regular";
+    chatMessageId = await postSimpleActionChat({
+      actor,
+      dieType,
+      amount: validation.total,
+      before,
+      after,
+      chatVisibility,
+      source,
+    });
+  }
+
+  return buildEnvelope({
+    ok: true,
+    reason: null,
+    context: { type: contextType, source },
+    amountRequested: requestedTotal,
+    breakdownRequested: { horror: requestedHorror, regular: Math.max(0, requestedTotal - requestedHorror) },
+    appliedTotal: applied.total,
+    appliedBreakdown: { regular: applied.regular, horror: applied.horror },
+    before: { dicepool: before.dicepool, horror: before.horror },
+    after: { dicepool: after.dicepool, horror: after.horror },
+    chat: {
+      posted: Boolean(chatMessageId),
+      messageId: chatMessageId,
+      visibility: chatVisibility,
+    },
+    actor,
+  });
+}
+
+export function canSpendDice(actor, {
+  totalDiceCost,
+  horrorDiceCost,
+  context = "simple",
+} = {}) {
+  const snapshot = getDiceSnapshot(actor);
+  const total = Math.max(0, toNumber(totalDiceCost, 0));
+  const requestedHorror = horrorDiceCost === undefined || horrorDiceCost === null
+    ? resolveAutoHorrorSpend({ totalDiceCost: total, snapshot })
+    : Math.max(0, toNumber(horrorDiceCost, 0));
+
+  const validation = validateDiceSpend({ snapshot, totalDiceCost: total, horrorDiceCost: requestedHorror });
+
+  return {
+    ok: validation.ok,
+    reason: validation.ok ? null : validation.reason,
+    maxSpendable: snapshot.dicepool,
+    failures: validation.ok ? [] : [validation.reason],
+    context: { type: toContextType(context) },
+  };
+}
+
+export function previewDiceSpend(actor, {
+  totalDiceCost,
+  horrorDiceCost,
+  context = "simple",
+} = {}) {
+  const before = getDiceSnapshot(actor);
+  const total = Math.max(0, toNumber(totalDiceCost, 0));
+  const requestedHorror = horrorDiceCost === undefined || horrorDiceCost === null
+    ? resolveAutoHorrorSpend({ totalDiceCost: total, snapshot: before })
+    : Math.max(0, toNumber(horrorDiceCost, 0));
+
+  const validation = validateDiceSpend({ snapshot: before, totalDiceCost: total, horrorDiceCost: requestedHorror });
+  if (!validation.ok) {
+    return buildEnvelope({
+      ok: false,
+      reason: validation.reason,
+      context: { type: toContextType(context) },
+      amountRequested: total,
+      breakdownRequested: { horror: requestedHorror, regular: Math.max(0, total - requestedHorror) },
+      appliedTotal: 0,
+      appliedBreakdown: { regular: 0, horror: 0 },
+      before: { dicepool: before.dicepool, horror: before.horror },
+      after: { dicepool: before.dicepool, horror: before.horror },
+      chat: { posted: false },
+      actor,
+    });
+  }
+
+  const after = {
+    dicepool: Math.max(0, before.dicepool - validation.total),
+    horror: Math.max(0, before.horrorInPool - validation.horror),
+    horrorInPool: Math.max(0, before.horrorInPool - validation.horror),
+    horrorLimit: before.horrorLimit,
+  };
+
+  return buildEnvelope({
+    ok: true,
+    reason: null,
+    context: { type: toContextType(context) },
+    amountRequested: total,
+    breakdownRequested: { horror: requestedHorror, regular: Math.max(0, total - requestedHorror) },
+    appliedTotal: validation.total,
+    appliedBreakdown: { regular: validation.regular, horror: validation.horror },
+    before: { dicepool: before.dicepool, horror: before.horror },
+    after,
+    chat: { posted: false },
+    actor,
+  });
+}
+
+export async function spendSimpleActionDie(actor, {
+  dieType = "regular",
+  context = "simple",
+  postChat = true,
+  chatVisibility = "public",
+  source = "sheet",
+} = {}) {
+  const normalized = String(dieType ?? "regular").toLowerCase() === "horror" ? "horror" : "regular";
+  return spendDiceCore({
+    actor,
+    totalDiceCost: 1,
+    horrorDiceCost: normalized === "horror" ? 1 : 0,
+    context,
+    postChat,
+    chatVisibility,
+    source,
+  });
+}
+
+export async function spendRollCost(actor, {
+  totalDiceCost,
+  horrorDiceCost,
+  context = "complex",
+  source = "workflow",
+} = {}) {
+  return spendDiceCore({
+    actor,
+    totalDiceCost,
+    horrorDiceCost,
+    context,
+    postChat: false,
+    source,
+  });
+}
+
+export async function discardDice(actor, {
+  amount = 1,
+  context = "discard",
+  postChat = true,
+  chatVisibility = "public",
+  source = "sheet",
+} = {}) {
+  const before = getDiceSnapshot(actor);
+  const breakdown = resolveDiscardBreakdown({ snapshot: before, amount });
+  const result = await spendDiceCore({
+    actor,
+    totalDiceCost: breakdown.requested,
+    horrorDiceCost: breakdown.horror,
+    context,
+    postChat: false,
+    chatVisibility,
+    source,
+  });
+
+  if (!result?.ok || !postChat) return result;
+
+  const chatMessageId = await postDiscardChat({
+    actor,
+    amount: breakdown.requested,
+    discardedRegular: breakdown.regular,
+    discardedHorror: breakdown.horror,
+    before,
+    after: result.after ?? before,
+    chatVisibility,
+    source,
+  });
+
+  return {
+    ...result,
+    chat: {
+      posted: Boolean(chatMessageId),
+      messageId: chatMessageId,
+      visibility: chatVisibility,
+    },
+  };
+}
+
+export async function discardAllDice(actor, {
+  context = "discard",
+  postChat = true,
+  chatVisibility = "public",
+  source = "sheet",
+} = {}) {
+  const snapshot = getDiceSnapshot(actor);
+  return discardDice(actor, {
+    amount: snapshot.dicepool,
+    context,
+    postChat,
+    chatVisibility,
+    source,
+  });
+}

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -233,6 +233,43 @@
 
 // Dice roll dialog: tidy up the Knacks selector layout.
 .roll-dialog-container {
+  .roll-resource-row {
+    > label {
+      flex: 0 0 130px;
+      min-width: 130px;
+    }
+  }
+
+  .roll-resource-controls {
+    flex: 1 1 auto;
+    width: 100%;
+    display: grid;
+    grid-template-columns: 36px minmax(0, 1fr) 10px minmax(0, 1fr) 36px;
+    align-items: center;
+    column-gap: 4px;
+
+    > input[type="number"] {
+      width: auto;
+      max-width: none;
+      min-width: 0;
+      text-align: center;
+    }
+
+    > .button-dicepool-rolldialog {
+      width: 36px;
+      min-width: 36px;
+      max-width: 36px;
+      padding: 0;
+      text-align: center;
+    }
+  }
+
+  .roll-resource-separator {
+    width: 10px;
+    text-align: center;
+    line-height: 1;
+  }
+
   .dialog-footer--primary {
     margin-top: 10px;
     margin-bottom: 6px;
@@ -736,7 +773,8 @@
   justify-content: center;
 
   .dicepool-dice {
-    margin-right: 5px;
+    margin-left: 3px;
+    margin-right: 3px;
   }
 }
 
@@ -803,6 +841,12 @@
   margin-left: 5px;
   margin-right: 5px;
   cursor: pointer;
+
+  img {
+    height: 24px;
+    width: 24px;
+    display: block;
+  }
 }
 
 .tab-biography, .tab-abilities {

--- a/templates/actor/parts/character-dicepool.hbs
+++ b/templates/actor/parts/character-dicepool.hbs
@@ -1,16 +1,17 @@
 <div class="dicepool-display">
-    <span class="dice-action-icon" data-action="clickedClearDicePool" title="{{localize "ARKHAM_HORROR.ACTIONS.ClearDicePool"}}" ><i class="fa-solid fa-x"></i></span>
+    <span class="dice-action-icon" data-action="clickedClearDicePool" title="{{localize "ARKHAM_HORROR.ACTIONS.DiscardAllDice"}}" ><i class="fa-solid fa-x"></i></span>
+    <span class="dice-action-icon" data-action="clickedDiscardDie" title="{{localize "ARKHAM_HORROR.ACTIONS.DiscardDie"}}"><i class="fa-solid fa-minus"></i></span>
+    <span class="dice-action-icon" data-action="clickedStrainOneself" title="{{localize "ARKHAM_HORROR.ACTIONS.StrainOneself"}}"><i class="fa-solid fa-hand-fist"></i></span>
     {{#each system.dicepoolPrepared as |die|}}
         {{#if die.isHorrorDice}}
-        <span class="dice-icon dicepool-dice color-d6 {{#if die.used}}used{{/if}}" data-action="clickedDicePool"
-            data-die-index="{{die.index}}"><img src="systems/arkham-horror-rpg-fvtt/assets/icons/icon-horror.svg"
+        <span class="dice-icon dicepool-dice color-d6 {{#if die.used}}used{{/if}}" data-action="clickedDicePool" data-die-index="{{die.index}}"><img src="systems/arkham-horror-rpg-fvtt/assets/icons/icon-horror.svg"
                 alt="Horror Die" /></span>
         {{else}}
-        <span class="dice-icon dicepool-dice color-d6 {{#if die.used}}used{{/if}}" data-action="clickedDicePool"
-            data-die-index="{{die.index}}"><img src="systems/arkham-horror-rpg-fvtt/assets/icons/icon-dice-d6.svg"
+        <span class="dice-icon dicepool-dice color-d6 {{#if die.used}}used{{/if}}" data-action="clickedDicePool" data-die-index="{{die.index}}"><img src="systems/arkham-horror-rpg-fvtt/assets/icons/icon-dice-d6.svg"
                 alt="Regular Die" /></span>
         {{/if}}
     {{/each}}
-    <span class="dice-action-icon" data-action="clickedStrainOneself" title="{{localize "ARKHAM_HORROR.ACTIONS.StrainOneself"}}"><i class="fa-solid fa-hand-fist"></i></span>
+    <span class="dice-action-icon" data-action="clickedSpendRegularDie" title="{{localize "ARKHAM_HORROR.ACTIONS.SpendRegularDie"}}"><i class="fa-solid fa-dice" aria-hidden="true"></i></span>
+    <span class="dice-action-icon" data-action="clickedSpendHorrorDie" title="{{localize "ARKHAM_HORROR.ACTIONS.SpendHorrorDie"}}"><i class="fa-solid fa-skull" aria-hidden="true"></i></span>
     <span class="dice-action-icon" data-action="clickedRefreshDicePool" title="{{localize "ARKHAM_HORROR.ACTIONS.RefreshDicePool"}}" ><i class="fa-solid fa-arrow-rotate-right"></i></span>
 </div>

--- a/templates/chat/dicepool-discard.hbs
+++ b/templates/chat/dicepool-discard.hbs
@@ -1,0 +1,3 @@
+<div>
+    <strong>{{localize "ARKHAM_HORROR.Chat.DicepoolDiscard.Label"}}</strong>: {{localize "ARKHAM_HORROR.Chat.DicepoolDiscard.Spent" actorName=actorName amount=amount discardedRegular=discardedRegular discardedHorror=discardedHorror oldDicePoolValue=oldDicePoolValue newDicePoolValue=newDicePoolValue}}
+</div>

--- a/templates/chat/simple-action-spend.hbs
+++ b/templates/chat/simple-action-spend.hbs
@@ -1,0 +1,3 @@
+<div>
+    <strong>{{localize "ARKHAM_HORROR.Chat.SimpleAction.Label"}}</strong>: {{localize "ARKHAM_HORROR.Chat.SimpleAction.Spent" actorName=actorName amount=amount dieTypeLabel=dieTypeLabel oldDicePoolValue=oldDicePoolValue newDicePoolValue=newDicePoolValue}}
+</div>

--- a/templates/dice-roll-app/dialog.hbs
+++ b/templates/dice-roll-app/dialog.hbs
@@ -1,13 +1,26 @@
 <form class="roll-dialog-container scrollable">
-    <div class="form-group">
+    <div class="form-group roll-resource-row">
         <label for="dicepool">{{localize "ARKHAM_HORROR.LABELS.Dicepool"}}</label>
-        <div class="flexrow">
+        <div class="flexrow roll-resource-controls">
             <button class="button-dicepool-rolldialog" data-action="clickedDecreaseDicePool" {{#if isReaction}}disabled{{/if}}>-</button>
-            <input type="number" id="dicepool" name="diceToUse" value="{{diceToUse}}" min="0" {{#if isReaction}}readonly{{/if}}> / 
+            <input type="number" id="dicepool" name="diceToUse" value="{{diceToUse}}" min="0" {{#if isReaction}}readonly{{/if}}>
+            <span class="roll-resource-separator">/</span>
             <input type="number" name="currentDicePool" value="{{currentDicePool}}" min="0" readonly>
             <button class="button-dicepool-rolldialog" data-action="clickedIncreaseDicePool" {{#if isReaction}}disabled{{/if}}>+</button>
         </div>
     </div>
+    {{#if showHorrorSelector}}
+    <div class="form-group roll-resource-row">
+        <label for="horror-dice-to-use">{{localize "ARKHAM_HORROR.Dialog.DiceRoll.HorrorDiceToUse"}}</label>
+        <div class="flexrow roll-resource-controls">
+            <button class="button-dicepool-rolldialog" data-action="clickedDecreaseHorrorDice">-</button>
+            <input type="number" id="horror-dice-to-use" name="horrorDiceToUse" value="{{horrorDiceToUse}}" min="{{minHorrorDiceToUse}}" max="{{maxHorrorDiceToUse}}">
+            <span class="roll-resource-separator">/</span>
+            <input type="number" name="availableHorror" value="{{availableHorror}}" min="0" readonly>
+            <button class="button-dicepool-rolldialog" data-action="clickedIncreaseHorrorDice">+</button>
+        </div>
+    </div>
+    {{/if}}
     <div class="form-group">
         <label for="roll-kind">{{localize "ARKHAM_HORROR.PROPS.RollType"}}</label>
         <input type="text" id="roll-kind" name="rollKindLabel" value="{{rollKindLabel}}" readonly>


### PR DESCRIPTION
### Overview
Implementation of [Feature Request] https://github.com/MrTheBino/arkham-horror-rpg-fvtt/issues/32 , and a lot of additional work as this introduces a breaking change for the TAH module.
This PR introduces a stable public API surface for external integrations (e.g. HUD modules) and internal use by GM's (e.g. macros).  We add explicit horror-dice spend handling across roll workflows, and also introduce the ability to spend / discard from the dice pool with chat notification.

### BREAKING CHANGE - EXTERNAL MODULE / MACROS
Breaking-change advisory: Token Action Hud: Arkham Horror module v13.0.2 does not correctly update dicepool via increment/decrement actions on Arkham Horror RPG system >= 13.0.37. Users should upgrade to Token Action Hud: Arkham Horror module v13.0.3 or newer when upgrading the base system.

If you have any macros that relied on calling exported functions to manipulate the number of dice in the dicepool you may need to verify that your macro still functions properly, in this situation we recommend specifically using the new api that we have exposed at: game.arkhamhorrorrpgfvtt.api.dicepool.setValue(actor, options).  If you are creating macros for Arkham Horror we also recommend utilizing the listed api's in this PR to accomplish as these are less likely to experience breaking changes in the future.

### IMPORTANT SYSTEM GAME PLAY CHANGE NOTE
With this implementation we not only have addressed the player's ability to spend horror dice at will but **we have made the timing of application of horror dice to the pool "rules correct"**  Please do not submit an issue when you notice this behavior on upgrade, unless the incorrect amount of horror dice are being applied on refresh/refill.

From pg 36 of the Arkham Horror RPG Core Rulebook:

> When a character suffers an amount of horror they increase their horror dice limit by an equal amount.  A character's horror dice limit cannot be increased higher than the character's dice pool maximum.  The horror dice limit determines how many dice in a character's dice pool are regular dice, and how many are horror dice.  **Whenever a character refills their dice pool**, they must first add horror dice up to their characters horror dice limit to their pool.

Prior to this PR and version the horror limit = the horror dice in pool.  Which meant that players when raising their horror dice limit immediately saw their horror dice in pool change.  Because this change requires us to track horror and regular separately we now follow the correct rules procedure and only add horror dice to the pool on dicepool refresh/refill.

### User facing changes

#### Dicepool
We have added 3 buttons to the dicepool section that enable players and game masters more knowledge of game state and history through chat posting:
1. Spend Regular Die (which spends 1 regular die from the pool and posts to chat)
2. Spend Horror Die (which spends 1 horror die from the pool and posts to chat)
3. Discard 1 Die (which removes 1 die prioritizing standard dice per the game rules, and posts to chat) <- this is due to certain traumas and other effects requiring a player to discard 1 die, it also allows a hook point for future automation of injury/trauma application etc.
4. Reworked "Clear" button to name it "Discard All Dice" and this now also posts to chat 
5. We have maintained a clickhandler compatibility to manipulate the dicepool amount by clicking anywhere on the dicepool to set the value without posting to chat, however the underlying logic of this has been reworked to fill horror dice first regardless of whether horror / standard have been spent.

The above functions now also come with UI warnings about whether things are in the pool to spend or not.

<img width="988" height="811" alt="image" src="https://github.com/user-attachments/assets/d6513d27-36da-4403-9eb0-33f643890c35" />

**Demonstrating that horror and standard can be spent separately**
<img width="696" height="299" alt="image" src="https://github.com/user-attachments/assets/44757d3e-009c-478d-ac5e-6fd77f8f57ca" />

**UI Warning on attempting to spend regular dice when 0 in pool**
<img width="1606" height="452" alt="image" src="https://github.com/user-attachments/assets/bec68256-42ea-4d32-ae11-9c5ef243aa9d" />

#### Skill Roll / Reaction Roll / Weapon Roll / Spell Roll 
We have added an additional +/- to allow for selection of Horror Dice in all complex roll types, this also clamps to make sure that if the pool has horror in it a user can just click the + on the Dicepool and the horror will fill automatically after standard (this maintains legacy method of horror die selection)

<img width="686" height="825" alt="image" src="https://github.com/user-attachments/assets/3353880c-6efb-4dbc-9d18-36bf6e9bbf2f" />

### New Public API
To try to avoid causing hard breaking changes in external modules and user macros in the future we now expose the following API from the system for use by module developers and macros.

**game.arkhamhorrorrpgfvtt.api.resources**

- canSpend(actor, options)
- previewSpend(actor, options)
- spendResource(actor, options) - Only dicepool right now
- spendSimpleActionDie(actor, options)
- spendRollCost(actor, options)
- discardDice(actor, options)
- discardAllDice(actor, options)

**game.arkhamhorrorrpgfvtt.api.rolls**

- openSkillDialog(actor, options)
- openReactionDialog(actor, options)
- openWeaponDialog(actor, options)
- openSpellDialog(actor, options)
- openInjuryTraumaDialog(actor, options)

**game.arkhamhorrorrpgfvtt.api.insight**

- openSpendDialog(actor)
- spendAndPost(actor, options)
- refreshAndPost(actor, options)

**game.arkhamhorrorrpgfvtt.api.dicepool**

- adjustDamage(actor, options)
- adjustHorror(actor, options)
- adjustValue(actor, options)
- setValue(actor, options)
- refresh(actor, options)
- strain(actor, options)

**game.arkhamhorrorrpgfvtt.api** (Properties)

- version
- capabilities

### Small Fixes
Added localization for the feature introduced in 13.0.36 (weapon usage)
