### PR TITLE
Fix v14 actor data prep lifecycle

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -5,6 +5,8 @@
 export class ArkhamHorrorActor extends Actor {
   /** @override */
   prepareData() {
+    // This is currently a pass-through hook. If no document-level prep is needed,
+    // prefer removing the override rather than shadowing the core lifecycle.
     // Prepare data for the actor. Calling the super version of this executes
     // the following, in order: data reset (to clear active effects),
     // prepareBaseData(), prepareEmbeddedDocuments() (including active effects),
@@ -40,6 +42,10 @@ export class ArkhamHorrorActor extends Actor {
 
   /** @override */
   prepareBaseData() {
+    // Foundry v14 resets Active Effect cycle state here, so document overrides
+    // must call the parent implementation before adding custom logic.
+    super.prepareBaseData();
+
     // Data modifications in this step occur before processing embedded
     // documents or derived data.
   }
@@ -52,6 +58,8 @@ export class ArkhamHorrorActor extends Actor {
    * is queried and has a roll executed directly from it).
    */
   prepareDerivedData() {
+    // Keep document-level derived logic here only for values that do not belong
+    // in the actor TypeDataModel. Flags are still consulted here for that reason.
     const actorData = this;
     const flags = actorData.flags.arkhamhorrorrpgfvtt || {};
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -43,6 +43,8 @@ export class ArkhamHorrorItem extends Item {
    * Augment the basic Item data model with additional dynamic data.
    */
   prepareData() {
+    // This is currently a pass-through hook. If item document-level prep is not
+    // needed, prefer removing the override rather than shadowing core behavior.
     // As with the actor class, items are documents that can have their data
     // preparation methods overridden (such as prepareBaseData()).
     super.prepareData();


### PR DESCRIPTION
This PR should remove the root cause of the errors that we were seeing below when moving to v14 from happening when these errors occurred especially on a new actor they caused the dicepool to fail to render.

However, we have also added some comments to other places where it appears that we have legacy override boiler plate, we can discuss fully removing these override functions as they are potential footguns in the future as prepareBaseData() was here on this version upgrade.

> foundry.mjs:26423 Error: Failed data preparation for Actor.nMUrL38mIF8QyGpM. Cannot set properties of undefined (setting 'initial')
> at Hooks.onError (foundry.mjs:26422:24)
> at ArkhamHorrorActor._safePrepareData (foundry.mjs:35845:17)
> at ArkhamHorrorActor._initialize (foundry.mjs:35631:12)
> at new DataModel (foundry.mjs:13302:10)
> at new Document (foundry.mjs:14139:1)
> at new BaseActor (foundry.mjs:17109:1)
> at new ClientDocumentMixin (foundry.mjs:35595:7)
> at new Actor (foundry.mjs:46096:15)
> at new ArkhamHorrorActor (actor.mjs:5:8)
> at Actors.createDocument (foundry.mjs:26552:12)Caused by: TypeError: Cannot set properties of undefined (setting 'initial')
> at ArkhamHorrorActor.applyActiveEffects (foundry.mjs:46317:42)
> at ArkhamHorrorActor.prepareEmbeddedDocuments (foundry.mjs:46530:10)
> at ArkhamHorrorActor.prepareData (foundry.mjs:35882:12)
> at ArkhamHorrorActor.prepareData (foundry.mjs:46492:11)
> at ArkhamHorrorActor.prepareData (actor.mjs:12:11)
> at ArkhamHorrorActor._safePrepareData (foundry.mjs:35843:14)
> at ArkhamHorrorActor._initialize (foundry.mjs:35631:12)
> at new DataModel (foundry.mjs:13302:10)
> at new Document (foundry.mjs:14139:1)
> at new BaseActor (foundry.mjs:17109:1)

The above was on creation of a new actor, but has also been tested in an existing world not upgrading foundry but migrating to v14 of AHRPG

The below was on a refreshdicepool

<img width="1221" height="818" alt="image" src="https://github.com/user-attachments/assets/15910d78-0b38-44df-8328-660769f37847" />

